### PR TITLE
chore: 배포 자동화 설정 추가

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -3,3 +3,6 @@ dependencies {
     //Spring MVC
     implementation 'org.springframework.boot:spring-boot-starter-web'
 }
+
+version '1.0.1-SNAPSHOT-'+new Date().format("yyyyMMddHHmmss")
+jar.enabled=false

--- a/api/src/main/java/com/garden/back/health/HealthChecker.java
+++ b/api/src/main/java/com/garden/back/health/HealthChecker.java
@@ -1,7 +1,6 @@
 package com.garden.back.health;
 
 import org.springframework.core.env.Environment;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,15 +8,15 @@ import java.util.Arrays;
 import java.util.List;
 
 @RestController
-public class healthChecker {
+public class HealthChecker {
 
     private final Environment environment;
 
-    public healthChecker(Environment environment) {
+    public HealthChecker(Environment environment) {
         this.environment = environment;
     }
 
-    @GetMapping(value = "/profile", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/profile")
     public String profile() {
         List<String> profiles = Arrays.asList(environment.getActiveProfiles());
         List<String> realProfiles = Arrays.asList("prod1", "prod2");

--- a/api/src/main/resources/application-prod1.yml
+++ b/api/src/main/resources/application-prod1.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8081

--- a/api/src/main/resources/application-prod2.yml
+++ b/api/src/main/resources/application-prod2.yml
@@ -1,0 +1,2 @@
+server:
+  port: 8082

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,18 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.2.0'
     id 'io.spring.dependency-management' version '1.1.4'
+    id "org.sonarqube" version "4.4.1.3373"
+}
+
+//sonar 설정
+sonar {
+    properties {
+        property "sonar.projectKey", "everyone-s-garden_back-V2"
+        property "sonar.organization", "everyone-s-garden"
+        property "sonar.host.url", "https://sonarcloud.io"
+        property 'sonar.coverage.exclusions', '**/health/**'
+        property 'sonar.exclusions', '**/*Application*.java'
+    }
 }
 
 group = 'com.graden'

--- a/build.gradle
+++ b/build.gradle
@@ -48,9 +48,30 @@ subprojects {
     apply plugin: 'java-library' //하위 모듈이 상위 모듈의 라이브러리를 의존할 수 있게 하는 플러그인
     apply plugin: 'io.spring.dependency-management'
     apply plugin: 'org.springframework.boot'
+    apply plugin: 'jacoco'
+    apply plugin: 'org.sonarqube' //하위 모듈에 전부 소나클라우드 적용
+
+    sonar {
+        properties {
+            property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/test/jacocoTestReport.xml"
+        }
+    }
 
     test {
         useJUnitPlatform()
+        finalizedBy jacocoTestReport
+    }
+
+    jacocoTestReport {
+        reports {
+            xml.required = true
+        }
+
+        afterEvaluate {
+            classDirectories.setFrom(files(classDirectories.files.collect {
+                fileTree(dir: it, exclude: ['**/*Request.class', '**/*Response.class'])
+            }))
+        }
     }
 
     dependencies {


### PR DESCRIPTION
## 설명
깃허브 액션 -> 현재 main 브랜치에 병합이 일어나면 발동하며 다음의 순서로 진행됩니다.
1. ssh 연결
2. build.sh 실행
    - 기존의 프로젝트 파일 삭제
    - git clone으로 프로젝트 파일 받기
    - build 하기
    - build 파일 jar 디렉토리 내로 옮기기
4. deploy.sh 실행
    - 현재 구동중인 포트 확인
    - 구동중인 포트 확인에 따라 앞으로 실행할 포트, 죽일 포트, 활성화 할 프로필 할당 (예를 들어 현재 prod1 프로필에 8081 포트가 구동되게 했는데, 현재 서비스가 8081 포트에 구동중이라면 앞으로 실행할 포트는 8082, 죽일 포트는 8081, 활성화 할 프로필은 prod2가 됩니다.)
    - 앞서 얻은 활성화 할 프로필과 함께 jar 파일 실행
    -  서비스가 배포되길 10초 기다렸다가 헬스체크 (10번 해보고 안되면 배포 실패)
    - 서비스가 성공적으로 배포 됐다면 nginx가 가르키는 포트 변경 후 nginx relaod (이 과정은 0.1초 내에 일어나기 때문에 서비스는 배포 중에도 중단 없이 돌아감)
    - 이전에 구동중이던 포트 죽이기

## 기대하는 동작
NCP에 배포 자동화를 했습니다. 서버 내에 build.sh, deploy.sh 스크립트를 보면 이해가 되실 겁니다.

## 추가 정보
이 문제와 관련된 추가적인 정보가 있다면 여기에 적어주세요.
