### PR TITLE
feat : 텃밭 관련 이미지 관련 자료형과 필드명을 통일

### DIFF
--- a/api/src/main/java/com/garden/back/garden/GardenController.java
+++ b/api/src/main/java/com/garden/back/garden/GardenController.java
@@ -79,6 +79,8 @@ public class GardenController {
                 .body(GardenDetailResponse.to(gardenDetail));
     }
 
+    //to-do : 최근 본 텃밭 등록하기
+
     @GetMapping(
             path = "/recent",
             produces = MediaType.APPLICATION_JSON_VALUE)

--- a/api/src/main/java/com/garden/back/garden/dto/response/GardenLikeByMemberResponses.java
+++ b/api/src/main/java/com/garden/back/garden/dto/response/GardenLikeByMemberResponses.java
@@ -21,7 +21,7 @@ public record GardenLikeByMemberResponses(
             String gardenName,
             String price,
             String gardenStatus,
-            List<String> imageUrls
+            List<String> images
     ) {
         public static GardenLikeByMemberResponse to(GardenLikeByMemberResults.GardenLikeByMemberResult gardenLikeByMemberResult) {
             return new GardenLikeByMemberResponse(

--- a/api/src/main/java/com/garden/back/garden/dto/response/GardenMineResponses.java
+++ b/api/src/main/java/com/garden/back/garden/dto/response/GardenMineResponses.java
@@ -21,7 +21,7 @@ public record GardenMineResponses(
             String gardenName,
             String price,
             String gardenStatus,
-            List<String> imageUrls
+            List<String> images
     ) {
         public static GardenMineResponse to(GardenMineResults.GardenMineResult gardenMineResult) {
             return new GardenMineResponse(

--- a/api/src/main/java/com/garden/back/garden/dto/response/MyManagedGardenDetailResponse.java
+++ b/api/src/main/java/com/garden/back/garden/dto/response/MyManagedGardenDetailResponse.java
@@ -2,13 +2,15 @@ package com.garden.back.garden.dto.response;
 
 import com.garden.back.garden.service.dto.response.MyManagedGardenDetailResult;
 
+import java.util.List;
+
 public record MyManagedGardenDetailResponse(
         Long myManagedGardenId,
         String gardenName,
         String address,
         String useStartDate,
         String useEndDate,
-        String imageUrl
+        List<String> images
 ) {
     public static MyManagedGardenDetailResponse to(MyManagedGardenDetailResult result) {
         return new MyManagedGardenDetailResponse(
@@ -17,7 +19,7 @@ public record MyManagedGardenDetailResponse(
                 result.address(),
                 result.useStartDate(),
                 result.useEndDate(),
-                result.imageUrl()
+                List.of(result.imageUrl())
         );
     }
 }

--- a/api/src/main/java/com/garden/back/garden/dto/response/MyManagedGardenGetResponses.java
+++ b/api/src/main/java/com/garden/back/garden/dto/response/MyManagedGardenGetResponses.java
@@ -19,7 +19,7 @@ public record MyManagedGardenGetResponses (
             String gardenName,
             String useStartDate,
             String useEndDate,
-            String imageUrl
+            List<String> images
     ){
         public static MyManagedGardenGetResponse to(MyManagedGardenGetResults.MyManagedGardenGetResult result) {
             return new MyManagedGardenGetResponse(
@@ -27,7 +27,7 @@ public record MyManagedGardenGetResponses (
                     result.gardenName(),
                     result.useStartDate(),
                     result.useEndDate(),
-                    result.imageUrl()
+                    result.images()
             );
         }
     }

--- a/api/src/main/java/com/garden/back/garden/dto/response/RecentGardenResponses.java
+++ b/api/src/main/java/com/garden/back/garden/dto/response/RecentGardenResponses.java
@@ -20,7 +20,7 @@ public record RecentGardenResponses(
             String size,
             String gardenName,
             String price,
-            String images,
+            List<String> images,
             String gardenStatus,
             String gardenType
     ) {

--- a/api/src/test/java/com/garden/back/docs/garden/GardenFixture.java
+++ b/api/src/test/java/com/garden/back/docs/garden/GardenFixture.java
@@ -90,7 +90,7 @@ public class GardenFixture {
                                 "1000",
                                 "영수네 텃밭",
                                 "100000",
-                                "www.garden.com",
+                                List.of("www.garden.com"),
                                 GardenStatus.ACTIVE.name(),
                                 GardenType.PUBLIC.name()
                         )
@@ -192,7 +192,7 @@ public class GardenFixture {
                                 "별이네 주말농장",
                                 "2023.12.01",
                                 "2023.12.31",
-                                "https://kr.object.ncloudstorage.com/every-garden/images/garden/background.jpg"
+                                List.of("https://kr.object.ncloudstorage.com/every-garden/images/garden/background.jpg")
                         )
                 )
         );

--- a/api/src/test/java/com/garden/back/docs/garden/GardenRestDocs.java
+++ b/api/src/test/java/com/garden/back/docs/garden/GardenRestDocs.java
@@ -193,7 +193,7 @@ class GardenRestDocs extends RestDocsSupport {
                                 fieldWithPath("recentGardenResponses[].size").type(JsonFieldType.STRING).description("텃밭 크기"),
                                 fieldWithPath("recentGardenResponses[].gardenName").type(JsonFieldType.STRING).description("텃밭 이름"),
                                 fieldWithPath("recentGardenResponses[].price").type(JsonFieldType.STRING).description("텃밭 가격"),
-                                fieldWithPath("recentGardenResponses[].images").type(JsonFieldType.STRING).description("텃밭 이미지"),
+                                fieldWithPath("recentGardenResponses[].images").type(JsonFieldType.ARRAY).description("텃밭 이미지"),
                                 fieldWithPath("recentGardenResponses[].gardenStatus").type(JsonFieldType.STRING).description("텃밭 상태 : ACTIVE(모집중), INACTIVE(마감)"),
                                 fieldWithPath("recentGardenResponses[].gardenType").type(JsonFieldType.STRING).description("텃밭 타입 : PRIVATE(민간), PUBLIC(공공)")
                         )));
@@ -229,7 +229,7 @@ class GardenRestDocs extends RestDocsSupport {
                                 fieldWithPath("gardenMineResponses[].gardenName").type(JsonFieldType.STRING).description("텃밭 이름"),
                                 fieldWithPath("gardenMineResponses[].price").type(JsonFieldType.STRING).description("텃밭 가격"),
                                 fieldWithPath("gardenMineResponses[].gardenStatus").type(JsonFieldType.STRING).description("텃밭 상태 : ACTIVE(모집중), INACTIVE(마감)"),
-                                fieldWithPath("gardenMineResponses[].imageUrls").type(JsonFieldType.ARRAY).description("텃밭 사진")
+                                fieldWithPath("gardenMineResponses[].images").type(JsonFieldType.ARRAY).description("텃밭 사진")
                         )));
     }
 
@@ -250,7 +250,7 @@ class GardenRestDocs extends RestDocsSupport {
                                 fieldWithPath("gardenLikeByMemberResponses[].gardenName").type(JsonFieldType.STRING).description("텃밭 이름"),
                                 fieldWithPath("gardenLikeByMemberResponses[].price").type(JsonFieldType.STRING).description("텃밭 가격"),
                                 fieldWithPath("gardenLikeByMemberResponses[].gardenStatus").type(JsonFieldType.STRING).description("텃밭 상태 : ACTIVE(모집중), INACTIVE(마감)"),
-                                fieldWithPath("gardenLikeByMemberResponses[].imageUrls").type(JsonFieldType.ARRAY).description("텃밭 사진")
+                                fieldWithPath("gardenLikeByMemberResponses[].images").type(JsonFieldType.ARRAY).description("텃밭 사진")
                         )));
     }
 
@@ -433,7 +433,7 @@ class GardenRestDocs extends RestDocsSupport {
                                 fieldWithPath("myManagedGardenGetResponses[].gardenName").type(JsonFieldType.STRING).description("가꾸는 텃밭의 농장 이름"),
                                 fieldWithPath("myManagedGardenGetResponses[].useStartDate").type(JsonFieldType.STRING).description("텃밭 사용 시작일"),
                                 fieldWithPath("myManagedGardenGetResponses[].useEndDate").type(JsonFieldType.STRING).description("텃밭 사용 종료일"),
-                                fieldWithPath("myManagedGardenGetResponses[].imageUrl").type(JsonFieldType.STRING).description("가꾸는 텃밭 대표 이미지 url")
+                                fieldWithPath("myManagedGardenGetResponses[].images").type(JsonFieldType.ARRAY).description("가꾸는 텃밭 대표 이미지 url")
                         )));
     }
 
@@ -569,7 +569,7 @@ class GardenRestDocs extends RestDocsSupport {
                                 fieldWithPath("address").type(JsonFieldType.STRING).description("분양받은 텃밭의 주소"),
                                 fieldWithPath("useStartDate").type(JsonFieldType.STRING).description("텃밭 사용 시작일"),
                                 fieldWithPath("useEndDate").type(JsonFieldType.STRING).description("텃밭 사용 종료일"),
-                                fieldWithPath("imageUrl").type(JsonFieldType.STRING).description("가꾸는 텃밭 대표 이미지 url")
+                                fieldWithPath("images").type(JsonFieldType.ARRAY).description("가꾸는 텃밭 대표 이미지 url")
                         )));
     }
 

--- a/core/src/main/java/com/garden/back/garden/service/dto/response/MyManagedGardenGetResults.java
+++ b/core/src/main/java/com/garden/back/garden/service/dto/response/MyManagedGardenGetResults.java
@@ -3,15 +3,16 @@ package com.garden.back.garden.service.dto.response;
 import com.garden.back.garden.repository.mymanagedgarden.dto.MyManagedGardensGetRepositoryResponse;
 
 import java.time.format.DateTimeFormatter;
-import java.util.List;
+import java.util.*;
 
 public record MyManagedGardenGetResults(
         List<MyManagedGardenGetResult> myManagedGardenGetRespons
 ) {
     public static MyManagedGardenGetResults to(List<MyManagedGardensGetRepositoryResponse> responses) {
+        Map<Long, List<String>> imagesPerGardenId = extractImages(responses);
         return new MyManagedGardenGetResults(
                 responses.stream()
-                        .map(MyManagedGardenGetResult::to)
+                        .map(response -> MyManagedGardenGetResult.to(response,imagesPerGardenId.get(response.getMyManagedGardenId())))
                         .toList()
         );
     }
@@ -21,19 +22,34 @@ public record MyManagedGardenGetResults(
             String gardenName,
             String useStartDate,
             String useEndDate,
-            String imageUrl
+            List<String> images
     ) {
         private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
-        public static MyManagedGardenGetResult to(MyManagedGardensGetRepositoryResponse response) {
+        public static MyManagedGardenGetResult to(
+                MyManagedGardensGetRepositoryResponse response,
+                List<String> images) {
             return new MyManagedGardenGetResult(
                     response.getMyManagedGardenId(),
                     response.getGardenName(),
                     response.getUseStartDate().format(DATE_FORMATTER),
                     response.getUseEndDate().format(DATE_FORMATTER),
-                    response.getImageUrl()
+                    images
             );
         }
 
+    }
+
+    private static Map<Long, List<String>> extractImages(List<MyManagedGardensGetRepositoryResponse> responses) {
+        Map<Long, List<String>> imagesPerGardenId = new HashMap<>();
+
+        responses.forEach(response -> {
+            Long gardenId = response.getMyManagedGardenId();
+            String imageUrl = response.getImageUrl();
+
+            imagesPerGardenId.computeIfAbsent(gardenId, k -> new ArrayList<>()).add(imageUrl);
+        });
+
+        return imagesPerGardenId;
     }
 }

--- a/core/src/main/java/com/garden/back/garden/service/dto/response/RecentGardenResults.java
+++ b/core/src/main/java/com/garden/back/garden/service/dto/response/RecentGardenResults.java
@@ -21,7 +21,7 @@ public record RecentGardenResults(
             String size,
             String gardenName,
             String price,
-            String images,
+            List<String> images,
             String gardenStatus,
             String gardenType
     ) {

--- a/core/src/main/java/com/garden/back/garden/service/recentview/RecentViewGarden.java
+++ b/core/src/main/java/com/garden/back/garden/service/recentview/RecentViewGarden.java
@@ -2,12 +2,14 @@ package com.garden.back.garden.service.recentview;
 
 import com.garden.back.garden.service.dto.response.GardenDetailResult;
 
+import java.util.List;
+
 public record RecentViewGarden(
         Long gardenId,
         String size,
         String gardenName,
         String price,
-        String images,
+        List<String> images,
         String gardenStatus,
         String gardenType
 ) {
@@ -17,7 +19,7 @@ public record RecentViewGarden(
                 gardenDetail.size(),
                 gardenDetail.gardenName(),
                 gardenDetail.price(),
-                gardenDetail.images().get(0),
+                gardenDetail.images(),
                 gardenDetail.gardenStatus(),
                 gardenDetail.gardenType()
         );

--- a/core/src/test/java/com/garden/back/garden/service/GardenReadServiceTest.java
+++ b/core/src/test/java/com/garden/back/garden/service/GardenReadServiceTest.java
@@ -253,11 +253,11 @@ class GardenReadServiceTest extends IntegrationTestSupport {
 
         // Then
         assertThat(myManagedGardenGetResults.myManagedGardenGetRespons())
-                .extracting("gardenName", "imageUrl")
+                .extracting("gardenName", "images")
                 .contains(
                         Tuple.tuple(
                                 savedPrivateGarden.getGardenName(),
-                                myManagedGarden.getImageUrl()
+                                List.of(myManagedGarden.getImageUrl())
                         )
                 );
     }

--- a/core/src/test/java/com/garden/back/garden/service/recentview/RecentViewGardensTest.java
+++ b/core/src/test/java/com/garden/back/garden/service/recentview/RecentViewGardensTest.java
@@ -18,7 +18,7 @@ class RecentViewGardensTest {
         RecentViewGardens recentViews = new RecentViewGardens(new ArrayDeque<>());
         for (long i = 0L; i < RecentViewGardens.MAX_RECENT_VIEW_COUNT + 5; i++) {
             RecentViewGarden garden = new RecentViewGarden(
-                    i, "Size", "Name", "Price", "Image", "Status", "Type");
+                    i, "Size", "Name", "Price", List.of("Image"), "Status", "Type");
             // When
             recentViews.addRecentViewGarden(garden);
         }

--- a/core/src/test/java/com/garden/back/testutil/garden/GardenFixture.java
+++ b/core/src/test/java/com/garden/back/testutil/garden/GardenFixture.java
@@ -162,8 +162,8 @@ public class GardenFixture {
                 1L,
                 "100",
                 "도연이네",
-                "www.everyGarden.com",
                 "10000",
+                List.of("www.everyGarden.com"),
                 GardenStatus.ACTIVE.name(),
                 GardenType.PUBLIC.name()
         );
@@ -174,8 +174,8 @@ public class GardenFixture {
                 1L,
                 "100",
                 "도연이네",
-                "www.everyGarden.com",
                 "10000",
+                List.of("www.everyGarden.com"),
                 GardenStatus.ACTIVE.name(),
                 GardenType.PRIVATE.name()
         );


### PR DESCRIPTION
## 내용
프론트 요청에 따라 image에 대한 자료형과 필드명을 통일합니다.
- 최근 본 텃밭 상세보기
- 내가 등록한 텃밭 상세보기
- 내가 찜한 텃밭 리스트 조회
- 내가 가꾸는 텃밭 목록 조회
- 내가 가꾸는 텃밭 상세보기
모두 List 자료형에 images라는 필드명으로 통일합니다.

