### PR TITLE
refactor : Garden 관련 도메인과 엔티티 분리 및 레파지토리 구조 변경

### DIFF
--- a/batch/src/main/java/com/garden/back/garden/FarmResponse.java
+++ b/batch/src/main/java/com/garden/back/garden/FarmResponse.java
@@ -1,6 +1,6 @@
 package com.garden.back.garden;
 
-import com.garden.back.garden.model.PublicDataGarden;
+import com.garden.back.garden.domain.PublicDataGarden;
 
 import java.util.List;
 

--- a/batch/src/test/java/com/garden/back/garden/OpenAPIGardenInfoClientTest.java
+++ b/batch/src/test/java/com/garden/back/garden/OpenAPIGardenInfoClientTest.java
@@ -1,6 +1,6 @@
 package com.garden.back.garden;
 
-import com.garden.back.garden.model.PublicDataGarden;
+import com.garden.back.garden.domain.PublicDataGarden;
 import com.garden.back.garden.repository.publicgarden.PublicDataGardenRepository;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;

--- a/core/src/main/java/com/garden/back/garden/domain/Garden.java
+++ b/core/src/main/java/com/garden/back/garden/domain/Garden.java
@@ -3,107 +3,46 @@ package com.garden.back.garden.domain;
 import com.garden.back.garden.domain.dto.GardenUpdateDomainRequest;
 import com.garden.back.garden.domain.vo.GardenStatus;
 import com.garden.back.garden.domain.vo.GardenType;
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.util.Assert;
-
 import java.time.LocalDate;
 import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
-@Table(name = "gardens")
 public class Garden {
 
     private static final int DEFAULT_REPORTED_SCORE = 0;
     private static final int DELETED_MAX_SCORE = 25;
     private static final int MIN_DESCRIPTION_LENGTH = 15;
 
-    @Id
-    @Column(name = "garden_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long gardenId;
-
-    @Column(name = "address", nullable = false)
     private String address;
-
-    @Column(name = "latitude", nullable = false)
     private Double latitude;
-
-    @Column(name = "longitude", nullable = false)
     private Double longitude;
-
-    @Column(name = "point" , nullable = false)
     private Point point;
-
-    @Column(name = "garden_name", nullable = false)
     private String gardenName;
-
-    @Enumerated(EnumType.STRING)
-    @Column(name = "garden_type", nullable = false)
     private GardenType gardenType;
-
-    @Enumerated(value = EnumType.STRING)
-    @Column(name = "garden_status", nullable = false)
     private GardenStatus gardenStatus;
-
-    @Column(name = "link_for_request")
     private String linkForRequest;
-
-    @Column(name = "price")
     private String price;
-
-    @Column(name = "contact")
     private String contact;
-
-    @Column(name = "size")
     private String size;
-
-    @Column(name = "garden_description", columnDefinition = "TEXT")
     private String gardenDescription;
-
-    @Column(name = "recruit_start_date")
     private LocalDate recruitStartDate;
-
-    @Column(name = "recruit_end_date")
     private LocalDate recruitEndDate;
-
-    @Column(name = "use_start_date")
     private LocalDate useStartDate;
-
-    @Column(name = "use_end_date")
     private LocalDate useEndDate;
-
-    @CreatedDate
-    @Column(name = "created_date")
     private LocalDate createdDate;
-
-    @LastModifiedDate
-    @Column(name = "last_modified_date")
     private LocalDate lastModifiedDate;
-
-    @Column(name = "is_toilet")
     private Boolean isToilet;
-
-    @Column(name = "is_waterway")
     private Boolean isWaterway;
-
-    @Column(name = "is_equipment")
     private Boolean isEquipment;
-
-    @Column(name = "writer_id")
     private Long writerId;
-
-    @Column(name = "is_deleted")
     private boolean isDeleted;
-
-    @Column(name = "reported_score")
     private int reportedScore;
 
     public void changeDelete() {
@@ -115,6 +54,126 @@ public class Garden {
         if (reportedScore > DELETED_MAX_SCORE) {
             changeDelete();
         }
+    }
+
+    protected Garden(
+            Long id,
+            String address,
+            Double latitude,
+            Double longitude,
+            Point point,
+            String gardenName,
+            GardenType gardenType,
+            GardenStatus gardenStatus,
+            String linkForRequest,
+            String price,
+            String contact,
+            String size,
+            String gardenDescription,
+            LocalDate recruitStartDate,
+            LocalDate recruitEndDate,
+            LocalDate useStartDate,
+            LocalDate useEndDate,
+            Boolean isToilet,
+            Boolean isWaterway,
+            Boolean isEquipment,
+            Long writerId,
+            boolean isDeleted,
+            int reportedScore) {
+
+        Assert.hasLength(address, "address는 null이거나 빈 값일 수 없습니다.");
+        Assert.notNull(latitude, "latitude는 null일 수 없습니다.");
+        Assert.notNull(longitude, "longitude는 null일 수 없습니다.");
+        Assert.notNull(point, "point는 null일 수 없습니다.");
+        Assert.hasLength(gardenName, "gardenName는 null이거나 빈 값일 수 없습니다.");
+        Assert.hasLength(linkForRequest, "linkForRequest는 null이거나 빈 값일 수 없습니다.");
+        Assert.hasLength(contact, "contact는 null이거나 빈 값일 수 없습니다.");
+        Assert.notNull(isToilet, "isToilet은 null일 수 없습니다.");
+        Assert.notNull(isWaterway, "isWaterway는 null일 수 없습니다.");
+        Assert.notNull(isEquipment, "isEquipment는 null일 수 없습니다.");
+
+        isNegativeReportedScore(reportedScore);
+        isNegativePrice(price);
+        isNegativeSize(size);
+        hasDefaultDescriptionLength(gardenDescription);
+        validateDate(useStartDate, useEndDate);
+        validateDate(recruitStartDate, recruitEndDate);
+
+        this.gardenId = id;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.point = point;
+        this.gardenName = gardenName;
+        this.gardenType = gardenType;
+        this.gardenStatus = gardenStatus;
+        this.linkForRequest = linkForRequest;
+        this.price = price;
+        this.contact = contact;
+        this.size = size;
+        this.gardenDescription = gardenDescription;
+        this.recruitStartDate = recruitStartDate;
+        this.recruitEndDate = recruitEndDate;
+        this.useStartDate = useStartDate;
+        this.useEndDate = useEndDate;
+        this.isToilet = isToilet;
+        this.isWaterway = isWaterway;
+        this.isEquipment = isEquipment;
+        this.writerId = writerId;
+        this.isDeleted = isDeleted;
+        this.reportedScore = reportedScore;
+    }
+
+    public static Garden of(
+            Long id,
+            String address,
+            Double latitude,
+            Double longitude,
+            Point point,
+            String gardenName,
+            GardenType gardenType,
+            GardenStatus gardenStatus,
+            String linkForRequest,
+            String price,
+            String contact,
+            String size,
+            String gardenDescription,
+            LocalDate recruitStartDate,
+            LocalDate recruitEndDate,
+            LocalDate useStartDate,
+            LocalDate useEndDate,
+            Boolean isToilet,
+            Boolean isWaterway,
+            Boolean isEquipment,
+            Long writerId,
+            boolean isDeleted,
+            int reportedScore
+    ) {
+        return new Garden(
+                id,
+                address,
+                latitude,
+                longitude,
+                point,
+                gardenName,
+                gardenType,
+                gardenStatus,
+                linkForRequest,
+                price,
+                contact,
+                size,
+                gardenDescription,
+                recruitStartDate,
+                recruitEndDate,
+                useStartDate,
+                useEndDate,
+                isToilet,
+                isWaterway,
+                isEquipment,
+                writerId,
+                isDeleted,
+                reportedScore
+        );
     }
 
     protected Garden(

--- a/core/src/main/java/com/garden/back/garden/domain/GardenImage.java
+++ b/core/src/main/java/com/garden/back/garden/domain/GardenImage.java
@@ -1,6 +1,5 @@
 package com.garden.back.garden.domain;
 
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,21 +7,37 @@ import org.springframework.util.Assert;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
-@Table(name = "garden_images")
 public class GardenImage {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "garden_image_id")
+
     private Long gardenImageId;
-
-    @Column(name = "image_url")
     private String imageUrl;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "garden_id")
     Garden garden;
+
+    protected GardenImage(
+            Long gardenImageId,
+            String imageUrl,
+            Garden garden
+    ) {
+        Assert.hasLength(imageUrl, "imageUrl은 null이거나 빈 값일 수 없습니다.");
+        Assert.notNull(garden, "garden은 null일 수 없습니다.");
+
+        this.gardenImageId =gardenImageId;
+        this.imageUrl = imageUrl;
+        this.garden = garden;
+    }
+
+    public static GardenImage of(
+            Long gardenImageId,
+            String imageUrl,
+            Garden garden
+    ) {
+        return new GardenImage(
+                gardenImageId,
+                imageUrl,
+                garden
+        );
+    }
 
     protected GardenImage(
             String imageUrl,

--- a/core/src/main/java/com/garden/back/garden/domain/GardenLike.java
+++ b/core/src/main/java/com/garden/back/garden/domain/GardenLike.java
@@ -11,27 +11,37 @@ import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
-@Table(name = "garden_likes", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"member_id", "garden_id"})
-})
 public class GardenLike {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "garden_like_id")
     private Long gardenLikeId;
-
-    @Column(name = "member_id")
     private Long memberId;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "garden_id")
     private Garden garden;
-
-    @CreatedDate
-    @Column(name = "created_date")
     private LocalDateTime createdDate;
+
+    protected GardenLike(
+            Long gardenLikeId,
+            Long memberId,
+            Garden garden
+    ) {
+        isNullOrNegativeMemberId(memberId);
+        Assert.notNull(garden, "garden은 null일 수 없습니다.");
+
+        this.gardenLikeId = gardenLikeId;
+        this.memberId = memberId;
+        this.garden = garden;
+    }
+
+    public static GardenLike of(
+            Long gardenLikeId,
+            Long memberId,
+            Garden garden
+    ) {
+        return new GardenLike(
+                gardenLikeId,
+                memberId,
+                garden
+        );
+    }
 
     protected GardenLike(
             Long memberId,

--- a/core/src/main/java/com/garden/back/garden/domain/MyManagedGarden.java
+++ b/core/src/main/java/com/garden/back/garden/domain/MyManagedGarden.java
@@ -5,6 +5,8 @@ import com.garden.back.garden.domain.dto.MyManagedGardenUpdateDomainRequest;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.util.Assert;
+
 import java.time.LocalDate;
 import java.util.Objects;
 
@@ -27,6 +29,12 @@ public class MyManagedGarden {
             String imageUrl,
             Long gardenId
     ) {
+        Assert.isTrue(myManagedGardenId > 0 , "myManagedGarden Id는 0보다 커야 합니다.");
+        Assert.isTrue(memberId > 0 , "member Id는 0보다 커야 합니다.");
+        Assert.isTrue(gardenId > 0 , "garden Id는 0보다 커야 합니다.");
+
+        validateDate(useStartDate,useEndDate);
+
         this.myManagedGardenId = myManagedGardenId;
         this.useStartDate = useStartDate;
         this.useEndDate = useEndDate;
@@ -60,6 +68,11 @@ public class MyManagedGarden {
             String imageUrl,
             Long gardenId
     ) {
+        Assert.isTrue(memberId > 0 , "member Id는 0보다 커야 합니다.");
+        Assert.isTrue(gardenId > 0 , "garden Id는 0보다 커야 합니다.");
+
+        validateDate(useStartDate,useEndDate);
+
         this.useStartDate = useStartDate;
         this.useEndDate = useEndDate;
         this.memberId = memberId;
@@ -96,6 +109,7 @@ public class MyManagedGarden {
     }
 
     public void update(MyManagedGardenUpdateDomainRequest request) {
+        Assert.isTrue(gardenId > 0 , "garden id는 0보다 커야 한다.");
         validWriterId(request.memberId());
         validateDate(request.useStartDate(), request.useEndDate());
 

--- a/core/src/main/java/com/garden/back/garden/domain/MyManagedGarden.java
+++ b/core/src/main/java/com/garden/back/garden/domain/MyManagedGarden.java
@@ -2,52 +2,69 @@ package com.garden.back.garden.domain;
 
 import com.garden.back.garden.domain.dto.MyManagedGardenCreateDomainRequest;
 import com.garden.back.garden.domain.dto.MyManagedGardenUpdateDomainRequest;
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import java.time.LocalDate;
 import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
-@Table(name="my_managed_gardens")
 public class MyManagedGarden {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "my_managed_garden_id")
     private Long myManagedGardenId;
-
-    @Column(name="use_start_date")
     private LocalDate useStartDate;
-
-    @Column(name="use_end_date")
     private LocalDate useEndDate;
-
-    @Column(name="member_id")
     private Long memberId;
-
-    @Column(name = "image_url")
     private String imageUrl;
-
-    @Column(name = "garden_id")
     private Long gardenId;
 
     protected MyManagedGarden(
-        LocalDate useStartDate,
-        LocalDate useEndDate,
-        Long memberId,
-        String imageUrl,
-        Long gardenId
-    ){
+            Long myManagedGardenId,
+            LocalDate useStartDate,
+            LocalDate useEndDate,
+            Long memberId,
+            String imageUrl,
+            Long gardenId
+    ) {
+        this.myManagedGardenId = myManagedGardenId;
         this.useStartDate = useStartDate;
         this.useEndDate = useEndDate;
         this.memberId = memberId;
         this.imageUrl = imageUrl;
-        this.gardenId =gardenId;
+        this.gardenId = gardenId;
+    }
+
+    public static MyManagedGarden of(
+            Long myManagedGardenId,
+            LocalDate useStartDate,
+            LocalDate useEndDate,
+            Long memberId,
+            String imageUrl,
+            Long gardenId
+    ) {
+        return new MyManagedGarden(
+                myManagedGardenId,
+                useStartDate,
+                useEndDate,
+                memberId,
+                imageUrl,
+                gardenId
+        );
+    }
+
+    protected MyManagedGarden(
+            LocalDate useStartDate,
+            LocalDate useEndDate,
+            Long memberId,
+            String imageUrl,
+            Long gardenId
+    ) {
+        this.useStartDate = useStartDate;
+        this.useEndDate = useEndDate;
+        this.memberId = memberId;
+        this.imageUrl = imageUrl;
+        this.gardenId = gardenId;
     }
 
     public static MyManagedGarden of(

--- a/core/src/main/java/com/garden/back/garden/domain/PublicDataGarden.java
+++ b/core/src/main/java/com/garden/back/garden/domain/PublicDataGarden.java
@@ -1,4 +1,4 @@
-package com.garden.back.garden.model;
+package com.garden.back.garden.domain;
 
 import jakarta.persistence.*;
 

--- a/core/src/main/java/com/garden/back/garden/repository/garden/GardenJpaRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/garden/GardenJpaRepository.java
@@ -1,12 +1,14 @@
 package com.garden.back.garden.repository.garden;
 
-import com.garden.back.garden.domain.Garden;
 import com.garden.back.garden.repository.garden.dto.GardenByName;
 import com.garden.back.garden.repository.garden.dto.GardenGetAll;
 import com.garden.back.garden.repository.garden.dto.response.GardenChatRoomInfoRepositoryResponse;
 import com.garden.back.garden.repository.garden.dto.response.GardenDetailRepositoryResponse;
 import com.garden.back.garden.repository.garden.dto.response.GardenLikeByMemberRepositoryResponse;
 import com.garden.back.garden.repository.garden.dto.response.GardenMineRepositoryResponse;
+import com.garden.back.garden.repository.garden.entity.GardenEntity;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,7 +17,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface GardenJpaRepository extends JpaRepository<Garden, Long>, GardenRepository, GardenCustomRepository {
+public interface GardenJpaRepository extends JpaRepository<GardenEntity, Long> {
 
     @Query(value = "select " +
             "g.garden_id as gardenId, " +
@@ -41,9 +43,9 @@ public interface GardenJpaRepository extends JpaRepository<Garden, Long>, Garden
                     g.gardenStatus as gardenStatus,
                     gi.imageUrl as imageUrl
                 FROM
-                    Garden g
+                    GardenEntity g
                 LEFT JOIN
-                    GardenImage gi ON g.gardenId = gi.garden.gardenId
+                    GardenImageEntity gi ON g.gardenId = gi.garden.gardenId
             """)
     Slice<GardenGetAll> getAllGardens(Pageable pageable);
 
@@ -72,11 +74,11 @@ public interface GardenJpaRepository extends JpaRepository<Garden, Long>, Garden
                     g.isWaterway as isWaterway,
                     g.isEquipment as isEquipment
                 FROM
-                    Garden g
+                    GardenEntity g
                 LEFT JOIN
-                    GardenLike l ON g.gardenId = l.garden.gardenId AND l.memberId = :memberId
+                    GardenLikeEntity l ON g.gardenId = l.garden.gardenId AND l.memberId = :memberId
                 LEFT JOIN
-                    GardenImage gi ON g.gardenId = gi.garden.gardenId
+                    GardenImageEntity gi ON g.gardenId = gi.garden.gardenId
                 WHERE g.gardenId =:gardenId
             """
     )
@@ -84,8 +86,6 @@ public interface GardenJpaRepository extends JpaRepository<Garden, Long>, Garden
             @Param("memberId") Long memberId,
             @Param("gardenId") Long gardenId
     );
-
-    Garden getById(Long gardenId);
 
     void deleteById(Long gardenId);
 
@@ -97,9 +97,9 @@ public interface GardenJpaRepository extends JpaRepository<Garden, Long>, Garden
              g.price as price,
              gi.imageUrl as imageUrl,
              g.gardenStatus as gardenStatus
-            from Garden as g
+            from GardenEntity as g
             left join
-             GardenImage as gi on g.gardenId = gi.garden.gardenId
+             GardenImageEntity as gi on g.gardenId = gi.garden.gardenId
             where g.writerId=:writerId
             """)
     List<GardenMineRepositoryResponse> findByWriterId(@Param("writerId") Long writerId);
@@ -113,11 +113,11 @@ public interface GardenJpaRepository extends JpaRepository<Garden, Long>, Garden
                      g.price as price,
                      gi.imageUrl as imageUrl,
                      g.gardenStatus as gardenStatus
-                    from Garden as g
+                    from GardenEntity as g
                     inner join
-                     GardenLike as gl on g.gardenId = gl.garden.gardenId and gl.memberId =:memberId
+                     GardenLikeEntity as gl on g.gardenId = gl.garden.gardenId and gl.memberId =:memberId
                     left join
-                     GardenImage as gi on g.gardenId = gi.garden.gardenId
+                     GardenImageEntity as gi on g.gardenId = gi.garden.gardenId
                     """
     )
     List<GardenLikeByMemberRepositoryResponse> getLikeGardenByMember(@Param("memberId") Long memberId);
@@ -129,9 +129,9 @@ public interface GardenJpaRepository extends JpaRepository<Garden, Long>, Garden
                      g.gardenStatus as gardenStatus,
                      g.price as price,
                      gi.imageUrl as imageUrl
-                    from Garden as g
+                    from GardenEntity as g
                     left join
-                     GardenImage as gi on g.gardenId = gi.garden.gardenId
+                     GardenImageEntity as gi on g.gardenId = gi.garden.gardenId
                     where g.gardenId =:gardenId
                     """
     )

--- a/core/src/main/java/com/garden/back/garden/repository/garden/GardenRepositoryImpl.java
+++ b/core/src/main/java/com/garden/back/garden/repository/garden/GardenRepositoryImpl.java
@@ -1,0 +1,85 @@
+package com.garden.back.garden.repository.garden;
+
+import com.garden.back.garden.domain.Garden;
+import com.garden.back.garden.repository.garden.dto.GardenByName;
+import com.garden.back.garden.repository.garden.dto.GardenGetAll;
+import com.garden.back.garden.repository.garden.dto.GardensByComplexes;
+import com.garden.back.garden.repository.garden.dto.request.GardenByComplexesRepositoryRequest;
+import com.garden.back.garden.repository.garden.dto.response.GardenChatRoomInfoRepositoryResponse;
+import com.garden.back.garden.repository.garden.dto.response.GardenDetailRepositoryResponse;
+import com.garden.back.garden.repository.garden.dto.response.GardenLikeByMemberRepositoryResponse;
+import com.garden.back.garden.repository.garden.dto.response.GardenMineRepositoryResponse;
+import com.garden.back.garden.repository.garden.entity.GardenEntity;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class GardenRepositoryImpl implements GardenRepository {
+
+    private final GardenJpaRepository gardenJpaRepository;
+    private final GardenCustomRepository gardenCustomRepository;
+
+    public GardenRepositoryImpl(GardenJpaRepository gardenJpaRepository, GardenCustomRepository gardenCustomRepository) {
+        this.gardenJpaRepository = gardenJpaRepository;
+        this.gardenCustomRepository = gardenCustomRepository;
+    }
+
+    @Override
+    public Slice<GardenByName> findGardensByName(String gardenName, Pageable pageable) {
+        return gardenJpaRepository.findGardensByName(gardenName,pageable);
+    }
+
+    @Override
+    public Slice<GardenGetAll> getAllGardens(Pageable pageable) {
+        return gardenJpaRepository.getAllGardens(pageable);
+    }
+
+    @Override
+    public GardensByComplexes getGardensByComplexes(GardenByComplexesRepositoryRequest request) {
+        return gardenCustomRepository.getGardensByComplexes(request);
+    }
+
+    @Override
+    public Garden save(Garden garden) {
+        return gardenJpaRepository.save(GardenEntity.from(garden)).toModel();
+    }
+
+    @Override
+    public List<GardenDetailRepositoryResponse> getGardenDetail(Long memberId, Long gardenId) {
+        return gardenJpaRepository.getGardenDetail(memberId,gardenId);
+    }
+
+    @Override
+    public Garden getById(Long gardenId) {
+        return gardenJpaRepository.findById(gardenId)
+                .orElseThrow(() ->
+                        new EmptyResultDataAccessException("존재하지 않는 텃밭 분양 정보: " + gardenId, 1 ))
+                .toModel();
+    }
+
+    @Override
+    public void deleteById(Long gardenId) {
+        gardenJpaRepository.deleteById(gardenId);
+    }
+
+    @Override
+    public List<GardenMineRepositoryResponse> findByWriterId(Long writerId) {
+        return gardenJpaRepository.findByWriterId(writerId);
+    }
+
+    @Override
+    public List<GardenLikeByMemberRepositoryResponse> getLikeGardenByMember(Long memberId) {
+        return gardenJpaRepository.getLikeGardenByMember(memberId);
+    }
+
+    @Override
+    public List<GardenChatRoomInfoRepositoryResponse> getChatRoomInfo(Long gardenId) {
+        return gardenJpaRepository.getChatRoomInfo(gardenId);
+    }
+
+}

--- a/core/src/main/java/com/garden/back/garden/repository/garden/entity/GardenEntity.java
+++ b/core/src/main/java/com/garden/back/garden/repository/garden/entity/GardenEntity.java
@@ -1,0 +1,166 @@
+package com.garden.back.garden.repository.garden.entity;
+
+import com.garden.back.garden.domain.Garden;
+import com.garden.back.garden.domain.vo.GardenStatus;
+import com.garden.back.garden.domain.vo.GardenType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "gardens")
+public class GardenEntity {
+
+    private static final int DEFAULT_REPORTED_SCORE = 0;
+    private static final int DELETED_MAX_SCORE = 25;
+    private static final int MIN_DESCRIPTION_LENGTH = 15;
+
+    @Id
+    @Column(name = "garden_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long gardenId;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    @Column(name = "point", nullable = false)
+    private Point point;
+
+    @Column(name = "garden_name", nullable = false)
+    private String gardenName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "garden_type", nullable = false)
+    private GardenType gardenType;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "garden_status", nullable = false)
+    private GardenStatus gardenStatus;
+
+    @Column(name = "link_for_request")
+    private String linkForRequest;
+
+    @Column(name = "price")
+    private String price;
+
+    @Column(name = "contact")
+    private String contact;
+
+    @Column(name = "size")
+    private String size;
+
+    @Column(name = "garden_description", columnDefinition = "TEXT")
+    private String gardenDescription;
+
+    @Column(name = "recruit_start_date")
+    private LocalDate recruitStartDate;
+
+    @Column(name = "recruit_end_date")
+    private LocalDate recruitEndDate;
+
+    @Column(name = "use_start_date")
+    private LocalDate useStartDate;
+
+    @Column(name = "use_end_date")
+    private LocalDate useEndDate;
+
+    @CreatedDate
+    @Column(name = "created_date")
+    private LocalDate createdDate;
+
+    @LastModifiedDate
+    @Column(name = "last_modified_date")
+    private LocalDate lastModifiedDate;
+
+    @Column(name = "is_toilet")
+    private Boolean isToilet;
+
+    @Column(name = "is_waterway")
+    private Boolean isWaterway;
+
+    @Column(name = "is_equipment")
+    private Boolean isEquipment;
+
+    @Column(name = "writer_id")
+    private Long writerId;
+
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
+
+    @Column(name = "reported_score")
+    private int reportedScore;
+
+    public Garden toModel() {
+        return Garden.of(
+                gardenId,
+                address,
+                latitude,
+                longitude,
+                point,
+                gardenName,
+                gardenType,
+                gardenStatus,
+                linkForRequest,
+                price,
+                contact,
+                size,
+                gardenDescription,
+                recruitStartDate,
+                recruitEndDate,
+                useStartDate,
+                useEndDate,
+                isToilet,
+                isWaterway,
+                isEquipment,
+                writerId,
+                isDeleted,
+                reportedScore
+
+        );
+    }
+
+    public static GardenEntity from(Garden garden) {
+        GardenEntity gardenEntity = new GardenEntity();
+        gardenEntity.gardenId = garden.getGardenId();
+        gardenEntity.address = garden.getAddress();
+        gardenEntity.latitude = garden.getLatitude();
+        gardenEntity.longitude = garden.getLongitude();
+        gardenEntity.point = garden.getPoint();
+        gardenEntity.gardenName = garden.getGardenName();
+        gardenEntity.gardenType = garden.getGardenType();
+        gardenEntity.gardenStatus = garden.getGardenStatus();
+        gardenEntity.linkForRequest = garden.getLinkForRequest();
+        gardenEntity.price = garden.getPrice();
+        gardenEntity.contact = garden.getContact();
+        gardenEntity.size = garden.getSize();
+        gardenEntity.gardenDescription = garden.getGardenDescription();
+        gardenEntity.recruitStartDate = garden.getRecruitStartDate();
+        gardenEntity.recruitEndDate = garden.getRecruitEndDate();
+        gardenEntity.useStartDate = garden.getUseStartDate();
+        gardenEntity.useEndDate = garden.getUseEndDate();
+        gardenEntity.isToilet = garden.getIsToilet();
+        gardenEntity.isWaterway = garden.getIsWaterway();
+        gardenEntity.isEquipment = garden.getIsEquipment();
+        gardenEntity.writerId = garden.getWriterId();
+        gardenEntity.isDeleted = garden.isDeleted();
+        gardenEntity.reportedScore = garden.getReportedScore();
+
+        return gardenEntity;
+    }
+
+}
+

--- a/core/src/main/java/com/garden/back/garden/repository/gardenimage/GardenImageJpaRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenimage/GardenImageJpaRepository.java
@@ -1,6 +1,6 @@
 package com.garden.back.garden.repository.gardenimage;
 
-import com.garden.back.garden.domain.GardenImage;
+import com.garden.back.garden.repository.gardenimage.entity.GardenImageEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -8,16 +8,16 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface GardenImageJpaRepository extends JpaRepository<GardenImage, Long> {
+public interface GardenImageJpaRepository extends JpaRepository<GardenImageEntity, Long> {
 
     @Modifying(clearAutomatically = true)
     @Query(
-            "delete from GardenImage as gi where gi.garden.gardenId =:gardenId"
+            "delete from GardenImageEntity as gi where gi.garden.gardenId =:gardenId"
     )
     void deleteByGardenId(@Param("gardenId") Long gardenId);
 
     @Query(
-            "select gi from GardenImage as gi where gi.garden.gardenId =:gardenId"
+            "select gi from GardenImageEntity as gi where gi.garden.gardenId =:gardenId"
     )
-    List<GardenImage> findByGardenId(@Param("gardenId") Long gardenId);
+    List<GardenImageEntity> findByGardenId(@Param("gardenId") Long gardenId);
 }

--- a/core/src/main/java/com/garden/back/garden/repository/gardenimage/GardenImageRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenimage/GardenImageRepository.java
@@ -1,5 +1,16 @@
 package com.garden.back.garden.repository.gardenimage;
 
-public interface GardenImageRepository extends GardenImageJpaRepository {
+import com.garden.back.garden.domain.GardenImage;
+
+import java.util.List;
+
+public interface GardenImageRepository {
     void deleteByGardenId(Long gardenId);
+
+    GardenImage save(GardenImage gardenImage);
+
+    List<GardenImage> findByGardenId(Long gardenId);
+
+    void delete(GardenImage gardenImage);
+
 }

--- a/core/src/main/java/com/garden/back/garden/repository/gardenimage/GardenImageRepositoryImpl.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenimage/GardenImageRepositoryImpl.java
@@ -1,0 +1,45 @@
+package com.garden.back.garden.repository.gardenimage;
+
+import com.garden.back.garden.domain.Garden;
+import com.garden.back.garden.domain.GardenImage;
+import com.garden.back.garden.repository.garden.GardenJpaRepository;
+import com.garden.back.garden.repository.gardenimage.entity.GardenImageEntity;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class GardenImageRepositoryImpl implements GardenImageRepository{
+
+    private final GardenImageJpaRepository gardenImageJpaRepository;
+    private final GardenJpaRepository gardenJpaRepository;
+
+    public GardenImageRepositoryImpl(GardenImageJpaRepository gardenImageJpaRepository, GardenJpaRepository gardenJpaRepository) {
+        this.gardenImageJpaRepository = gardenImageJpaRepository;
+        this.gardenJpaRepository = gardenJpaRepository;
+    }
+
+    @Override
+    public void deleteByGardenId(Long gardenId) {
+        gardenImageJpaRepository.deleteByGardenId(gardenId);
+    }
+
+    @Override
+    public GardenImage save(GardenImage gardenImage) {
+        return gardenImageJpaRepository.save(GardenImageEntity.from(gardenImage,
+                gardenJpaRepository.getById(gardenImage.getGarden().getGardenId()))).toModel();
+    }
+
+    @Override
+    public List<GardenImage> findByGardenId(Long gardenId) {
+        return gardenImageJpaRepository.findByGardenId(gardenId).stream()
+                .map(GardenImageEntity::toModel)
+                .toList();
+    }
+
+    @Override
+    public void delete(GardenImage gardenImage) {
+        gardenImageJpaRepository.delete(GardenImageEntity.from(gardenImage));
+    }
+
+}

--- a/core/src/main/java/com/garden/back/garden/repository/gardenimage/entity/GardenImageEntity.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenimage/entity/GardenImageEntity.java
@@ -1,0 +1,56 @@
+package com.garden.back.garden.repository.gardenimage.entity;
+
+import com.garden.back.garden.domain.Garden;
+import com.garden.back.garden.domain.GardenImage;
+import com.garden.back.garden.repository.garden.entity.GardenEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "garden_images")
+public class GardenImageEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "garden_image_id")
+    private Long gardenImageId;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "garden_id")
+    GardenEntity garden;
+
+    public GardenImage toModel() {
+        return GardenImage.of(
+                gardenImageId,
+                imageUrl,
+                garden.toModel()
+        );
+    }
+
+    public static GardenImageEntity from(GardenImage gardenImage, GardenEntity garden) {
+        GardenImageEntity gardenImageEntity = new GardenImageEntity();
+        gardenImageEntity.gardenImageId = gardenImage.getGardenImageId();
+        gardenImageEntity.imageUrl = gardenImage.getImageUrl();
+        gardenImageEntity.garden = garden;
+
+        return gardenImageEntity;
+    }
+
+    public static GardenImageEntity from(GardenImage gardenImage) {
+        GardenImageEntity gardenImageEntity = new GardenImageEntity();
+        gardenImageEntity.gardenImageId = gardenImage.getGardenImageId();
+        gardenImageEntity.imageUrl = gardenImage.getImageUrl();
+        gardenImageEntity.garden = GardenEntity.from(gardenImage.getGarden());
+
+        return gardenImageEntity;
+    }
+
+}

--- a/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeJpaRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeJpaRepository.java
@@ -1,17 +1,17 @@
 package com.garden.back.garden.repository.gardenlike;
 
-import com.garden.back.garden.domain.GardenLike;
+import com.garden.back.garden.repository.gardenlike.entity.GardenLikeEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface GardenLikeJpaRepository extends JpaRepository<GardenLike, Long> {
+public interface GardenLikeJpaRepository extends JpaRepository<GardenLikeEntity, Long> {
 
     @Modifying(clearAutomatically = true)
     @Query(
             """
-            delete from GardenLike as gl where gl.garden.gardenId =:gardenId and gl.memberId=:memberId
+            delete from GardenLikeEntity as gl where gl.garden.gardenId =:gardenId and gl.memberId=:memberId
             """)
     void delete(@Param("memberId") Long memberId, @Param("gardenId") Long gardenId);
 

--- a/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeRepository.java
@@ -1,4 +1,14 @@
 package com.garden.back.garden.repository.gardenlike;
 
-public interface GardenLikeRepository extends GardenLikeJpaRepository{
+import com.garden.back.garden.domain.GardenLike;
+
+import java.util.List;
+
+public interface GardenLikeRepository {
+    GardenLike save(GardenLike gardenLike);
+
+    void delete(Long memberId, Long gardenId);
+
+    List<GardenLike> findAll();
+
 }

--- a/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeRepositoryImpl.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.garden.back.garden.repository.gardenlike;
+
+import com.garden.back.garden.domain.GardenLike;
+import com.garden.back.garden.repository.garden.GardenJpaRepository;
+import com.garden.back.garden.repository.gardenlike.entity.GardenLikeEntity;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class GardenLikeRepositoryImpl implements GardenLikeRepository {
+
+    private final GardenLikeJpaRepository gardenLikeJpaRepository;
+    private final GardenJpaRepository gardenJpaRepository;
+
+    public GardenLikeRepositoryImpl(GardenLikeJpaRepository gardenLikeJpaRepository, GardenJpaRepository gardenJpaRepository) {
+        this.gardenLikeJpaRepository = gardenLikeJpaRepository;
+        this.gardenJpaRepository = gardenJpaRepository;
+    }
+
+    @Override
+    public GardenLike save(GardenLike gardenLike) {
+        return gardenLikeJpaRepository.save(GardenLikeEntity.from(gardenLike,
+                gardenJpaRepository.getById(gardenLike.getGarden().getGardenId()))).toModel();
+    }
+
+    @Override
+    public void delete(Long memberId, Long gardenId) {
+        gardenLikeJpaRepository.delete(memberId, gardenId);
+    }
+
+    @Override
+    public List<GardenLike> findAll() {
+        return gardenLikeJpaRepository.findAll().stream()
+                .map(GardenLikeEntity::toModel)
+                .toList();
+    }
+
+}

--- a/core/src/main/java/com/garden/back/garden/repository/gardenlike/entity/GardenLikeEntity.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenlike/entity/GardenLikeEntity.java
@@ -1,0 +1,63 @@
+package com.garden.back.garden.repository.gardenlike.entity;
+
+import com.garden.back.garden.domain.Garden;
+import com.garden.back.garden.domain.GardenLike;
+import com.garden.back.garden.repository.garden.entity.GardenEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.util.Assert;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "garden_likes")
+public class GardenLikeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "garden_like_id")
+    private Long gardenLikeId;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "garden_id")
+    private GardenEntity garden;
+
+    @CreatedDate
+    @Column(name = "created_date")
+    private LocalDateTime createdDate;
+
+    public GardenLike toModel() {
+        return GardenLike.of(
+                gardenLikeId,
+                memberId,
+                garden.toModel()
+        );
+    }
+
+    public static GardenLikeEntity from( GardenLike gardenLike, GardenEntity garden) {
+        GardenLikeEntity gardenLikeEntity = new GardenLikeEntity();
+        gardenLikeEntity.gardenLikeId = gardenLike.getGardenLikeId();
+        gardenLikeEntity.memberId = gardenLike.getMemberId();
+        gardenLikeEntity.garden = garden;
+
+        return gardenLikeEntity;
+    }
+
+    public static GardenLikeEntity from( GardenLike gardenLike) {
+       GardenLikeEntity gardenLikeEntity = new GardenLikeEntity();
+       gardenLikeEntity.gardenLikeId = gardenLike.getGardenLikeId();
+       gardenLikeEntity.memberId = gardenLike.getMemberId();
+       gardenLikeEntity.garden = GardenEntity.from(gardenLike.getGarden());
+
+       return gardenLikeEntity;
+    }
+
+}

--- a/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/MyManagedGardenJpaRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/MyManagedGardenJpaRepository.java
@@ -1,8 +1,8 @@
 package com.garden.back.garden.repository.mymanagedgarden;
 
-import com.garden.back.garden.domain.MyManagedGarden;
 import com.garden.back.garden.repository.mymanagedgarden.dto.MyManagedGardenDetailRepositoryResponse;
 import com.garden.back.garden.repository.mymanagedgarden.dto.MyManagedGardensGetRepositoryResponse;
+import com.garden.back.garden.repository.mymanagedgarden.entity.MyManagedGardenEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface MyManagedGardenJpaRepository extends JpaRepository<MyManagedGarden, Long> {
+public interface MyManagedGardenJpaRepository extends JpaRepository<MyManagedGardenEntity, Long> {
 
     @Query(
             """ 
@@ -20,7 +20,7 @@ public interface MyManagedGardenJpaRepository extends JpaRepository<MyManagedGar
                      mmg.useStartDate as useStartDate,
                      mmg.useEndDate as useEndDate,
                      g.gardenName as gardenName
-                    from MyManagedGarden as mmg
+                    from MyManagedGardenEntity as mmg
                     inner join GardenEntity as g on mmg.gardenId = g.gardenId
                     where mmg.memberId =:memberId
                     """
@@ -30,7 +30,7 @@ public interface MyManagedGardenJpaRepository extends JpaRepository<MyManagedGar
     @Modifying(clearAutomatically = true)
     @Query(
             """ 
-                    delete from MyManagedGarden as mmg where mmg.myManagedGardenId =:myManagedGardenId and mmg.memberId =:memberId
+                    delete from MyManagedGardenEntity as mmg where mmg.myManagedGardenId =:myManagedGardenId and mmg.memberId =:memberId
                     """
     )
     void delete(@Param("myManagedGardenId") Long myManagedGardenId, @Param("memberId") Long memberId);
@@ -44,7 +44,7 @@ public interface MyManagedGardenJpaRepository extends JpaRepository<MyManagedGar
                      mmg.useEndDate as useEndDate,
                      g.gardenName as gardenName,
                      g.address as address
-                    from MyManagedGarden as mmg
+                    from MyManagedGardenEntity as mmg
                     inner join GardenEntity as g on mmg.gardenId = g.gardenId
                     where mmg.myManagedGardenId =:myManagedGardenId
                     """

--- a/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/MyManagedGardenJpaRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/MyManagedGardenJpaRepository.java
@@ -21,7 +21,7 @@ public interface MyManagedGardenJpaRepository extends JpaRepository<MyManagedGar
                      mmg.useEndDate as useEndDate,
                      g.gardenName as gardenName
                     from MyManagedGarden as mmg
-                    inner join Garden as g on mmg.gardenId = g.gardenId
+                    inner join GardenEntity as g on mmg.gardenId = g.gardenId
                     where mmg.memberId =:memberId
                     """
     )
@@ -45,7 +45,7 @@ public interface MyManagedGardenJpaRepository extends JpaRepository<MyManagedGar
                      g.gardenName as gardenName,
                      g.address as address
                     from MyManagedGarden as mmg
-                    inner join Garden as g on mmg.gardenId = g.gardenId
+                    inner join GardenEntity as g on mmg.gardenId = g.gardenId
                     where mmg.myManagedGardenId =:myManagedGardenId
                     """
     )

--- a/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/MyManagedGardenRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/MyManagedGardenRepository.java
@@ -1,17 +1,26 @@
 package com.garden.back.garden.repository.mymanagedgarden;
 
 import com.garden.back.garden.domain.MyManagedGarden;
+import com.garden.back.garden.repository.mymanagedgarden.dto.MyManagedGardenDetailRepositoryResponse;
 import com.garden.back.garden.repository.mymanagedgarden.dto.MyManagedGardensGetRepositoryResponse;
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
-public interface MyManagedGardenRepository extends MyManagedGardenJpaRepository {
+public interface MyManagedGardenRepository {
 
     List<MyManagedGardensGetRepositoryResponse> getByMemberId(Long memberId);
 
-    default MyManagedGarden getById(Long myManagedGardenId) {
-        return findById(myManagedGardenId).orElseThrow(() -> new EntityNotFoundException("존재하지 않은 자원입니다."));
-    }
+    MyManagedGarden getById(Long myManagedGardenId);
+
+    MyManagedGarden save(MyManagedGarden myManagedGarden);
+
+    void delete(Long myManagedGardenId, Long memberId);
+
+    Optional<MyManagedGarden> findById(Long myManagedGardenId);
+
+    MyManagedGardenDetailRepositoryResponse getDetailById(Long myManagedGardenId);
 
 }

--- a/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/MyManagedGardenRepositoryImpl.java
+++ b/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/MyManagedGardenRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.garden.back.garden.repository.mymanagedgarden;
+
+import com.garden.back.garden.domain.MyManagedGarden;
+import com.garden.back.garden.repository.mymanagedgarden.dto.MyManagedGardenDetailRepositoryResponse;
+import com.garden.back.garden.repository.mymanagedgarden.dto.MyManagedGardensGetRepositoryResponse;
+import com.garden.back.garden.repository.mymanagedgarden.entity.MyManagedGardenEntity;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public class MyManagedGardenRepositoryImpl implements MyManagedGardenRepository {
+
+    private final MyManagedGardenJpaRepository myManagedGardenJpaRepository;
+
+    public MyManagedGardenRepositoryImpl(MyManagedGardenJpaRepository myManagedGardenJpaRepository) {
+        this.myManagedGardenJpaRepository = myManagedGardenJpaRepository;
+    }
+
+    @Override
+    public List<MyManagedGardensGetRepositoryResponse> getByMemberId(Long memberId) {
+        return myManagedGardenJpaRepository.getByMemberId(memberId);
+    }
+
+    @Override
+    public MyManagedGarden getById(Long myManagedGardenId) {
+        return myManagedGardenJpaRepository.findById(myManagedGardenId)
+                .orElseThrow(() -> new EmptyResultDataAccessException("존재하지 않는 가꾸는 텃밭 정보: " + myManagedGardenId, 1))
+                .toModel();
+    }
+
+    @Override
+    public MyManagedGarden save(MyManagedGarden myManagedGarden) {
+        return myManagedGardenJpaRepository.save(MyManagedGardenEntity.from(myManagedGarden)).toModel();
+    }
+
+    @Override
+    public void delete(Long myManagedGardenId, Long memberId) {
+        myManagedGardenJpaRepository.delete(myManagedGardenId, memberId);
+    }
+
+    @Override
+    public Optional<MyManagedGarden> findById(Long myManagedGardenId) {
+        return myManagedGardenJpaRepository.findById(myManagedGardenId)
+                .map(MyManagedGardenEntity::toModel);
+    }
+
+    @Override
+    public MyManagedGardenDetailRepositoryResponse getDetailById(Long myManagedGardenId) {
+        return myManagedGardenJpaRepository.getDetailById(myManagedGardenId);
+    }
+
+}

--- a/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/entity/MyManagedGardenEntity.java
+++ b/core/src/main/java/com/garden/back/garden/repository/mymanagedgarden/entity/MyManagedGardenEntity.java
@@ -1,0 +1,61 @@
+package com.garden.back.garden.repository.mymanagedgarden.entity;
+
+import com.garden.back.garden.domain.MyManagedGarden;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "my_managed_gardens")
+public class MyManagedGardenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "my_managed_garden_id")
+    private Long myManagedGardenId;
+
+    @Column(name = "use_start_date")
+    private LocalDate useStartDate;
+
+    @Column(name = "use_end_date")
+    private LocalDate useEndDate;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "garden_id")
+    private Long gardenId;
+
+    public MyManagedGarden toModel() {
+        return MyManagedGarden.of(
+                myManagedGardenId,
+                useStartDate,
+                useEndDate,
+                memberId,
+                imageUrl,
+                gardenId
+        );
+    }
+
+    public static MyManagedGardenEntity from(
+            MyManagedGarden myManagedGarden
+    ) {
+        MyManagedGardenEntity myManagedGardenEntity = new MyManagedGardenEntity();
+        myManagedGardenEntity.myManagedGardenId = myManagedGarden.getMyManagedGardenId();
+        myManagedGardenEntity.useStartDate = myManagedGarden.getUseStartDate();
+        myManagedGardenEntity.useEndDate = myManagedGarden.getUseEndDate();
+        myManagedGardenEntity.memberId = myManagedGarden.getMemberId();
+        myManagedGardenEntity.imageUrl = myManagedGarden.getImageUrl();
+        myManagedGardenEntity.gardenId = myManagedGarden.getGardenId();
+
+        return myManagedGardenEntity;
+    }
+}

--- a/core/src/main/java/com/garden/back/garden/repository/publicgarden/PublicDataGardenRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/publicgarden/PublicDataGardenRepository.java
@@ -1,6 +1,6 @@
 package com.garden.back.garden.repository.publicgarden;
 
-import com.garden.back.garden.model.PublicDataGarden;
+import com.garden.back.garden.domain.PublicDataGarden;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PublicDataGardenRepository extends JpaRepository<PublicDataGarden, Long> {

--- a/core/src/main/java/com/garden/back/garden/service/GardenCommandService.java
+++ b/core/src/main/java/com/garden/back/garden/service/GardenCommandService.java
@@ -76,6 +76,7 @@ public class GardenCommandService {
     public Long updateGarden(GardenUpdateParam param) {
         Garden gardenToUpdate = gardenRepository.getById(param.gardenId());
         gardenToUpdate.updateGarden(GardenUpdateParam.of(param));
+        gardenRepository.save(gardenToUpdate);
 
         deleteGardenImages(param.gardenId(), param.remainGardenImageUrls());
         saveNewGardenImages(gardenToUpdate, param.newGardenImages());

--- a/core/src/main/java/com/garden/back/garden/service/GardenCommandService.java
+++ b/core/src/main/java/com/garden/back/garden/service/GardenCommandService.java
@@ -123,6 +123,7 @@ public class GardenCommandService {
 
         List<String> uploadImageUrls = parallelImageUploader.upload(GARDEN_IMAGE_DIRECTORY, List.of(param.myManagedGardenImage()));
         myManagedGarden.update(MyManagedGardenUpdateParam.to(param, uploadImageUrls.get(MY_MANAGED_GARDEN_IMAGE_INDEX)));
+        myManagedGardenRepository.save(myManagedGarden);
 
         return myManagedGarden.getMyManagedGardenId();
     }

--- a/core/src/test/java/com/garden/back/garden/domain/MyManagedGardenTest.java
+++ b/core/src/test/java/com/garden/back/garden/domain/MyManagedGardenTest.java
@@ -1,0 +1,120 @@
+package com.garden.back.garden.domain;
+
+import com.garden.back.garden.domain.dto.MyManagedGardenUpdateDomainRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MyManagedGardenTest {
+
+    @DisplayName("memberId가 0이거나 0보다 작으면 예외를 던진다.")
+    @ParameterizedTest
+    @ValueSource(longs = {0, -1})
+    void throwException_zeroOrNegative_memberId(Long memberId) {
+        assertThrows(RuntimeException.class,
+                () -> MyManagedGarden.of(
+                        LocalDate.of(2023, 12, 12),
+                        LocalDate.of(2023, 12, 13),
+                        memberId,
+                        "https://kr.object.ncloudstorage.com/every-garden/images/garden/view.jpg",
+                        1L
+                ));
+    }
+
+    @DisplayName("gardenId가 0이거나 0보다 작으면 예외를 던진다.")
+    @ParameterizedTest
+    @ValueSource(longs = {0, -1})
+    void throwException_zeroOrNegative_gardenId(Long gardenId) {
+        assertThrows(RuntimeException.class,
+                () -> MyManagedGarden.of(
+                        LocalDate.of(2023, 12, 12),
+                        LocalDate.of(2023, 12, 13),
+                        1L,
+                        "https://kr.object.ncloudstorage.com/every-garden/images/garden/view.jpg",
+                        gardenId
+                ));
+    }
+
+    @DisplayName("myManagedId가 0이거나 0보다 작으면 예외를 던진다.")
+    @ParameterizedTest
+    @ValueSource(longs = {0, -1})
+    void throwException_zeroOrNegative_myManagedId(Long myManagedId) {
+        assertThrows(RuntimeException.class,
+                () -> MyManagedGarden.of(
+                        myManagedId,
+                        LocalDate.of(2023, 12, 12),
+                        LocalDate.of(2023, 12, 13),
+                        1L,
+                        "https://kr.object.ncloudstorage.com/every-garden/images/garden/view.jpg",
+                        1L
+                ));
+    }
+
+    @DisplayName("사용 시작일이 사용 마감일보다 이후이면 예외를 던진다.")
+    @Test
+    void throwException_beforeEndDate() {
+        assertThrows(RuntimeException.class,
+                () -> MyManagedGarden.of(
+                        LocalDate.of(2023, 12, 16),
+                        LocalDate.of(2023, 12, 13),
+                        1L,
+                        "https://kr.object.ncloudstorage.com/every-garden/images/garden/view.jpg",
+                        1L
+                ));
+    }
+
+    @DisplayName("업데이트 할 때 올바른 요청값인지 검증한다.")
+    @ParameterizedTest
+    @MethodSource("invalidMyManagedGardenUpdateDomainRequest")
+    void throwException_update_invalidRequest(MyManagedGardenUpdateDomainRequest request) {
+        MyManagedGarden myManagedGarden = myManagedGarden();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> myManagedGarden.update(request));
+    }
+
+    private static Stream<MyManagedGardenUpdateDomainRequest> invalidMyManagedGardenUpdateDomainRequest() {
+        return Stream.of(
+                new MyManagedGardenUpdateDomainRequest(
+                        "https://kr.object.ncloudstorage.com/every-garden/images/garden/view.jpg",
+                        1L,
+                        LocalDate.of(2023, 12, 12),
+                        LocalDate.of(2023, 12, 13),
+                        100L
+                ),
+                new MyManagedGardenUpdateDomainRequest(
+                        "https://kr.object.ncloudstorage.com/every-garden/images/garden/view.jpg",
+                        1L,
+                        LocalDate.of(2023, 12, 16),
+                        LocalDate.of(2023, 12, 13),
+                        1L
+                ),
+                new MyManagedGardenUpdateDomainRequest(
+                        "https://kr.object.ncloudstorage.com/every-garden/images/garden/view.jpg",
+                        -1L,
+                        LocalDate.of(2023, 12, 16),
+                        LocalDate.of(2023, 12, 13),
+                        1L
+                )
+        );
+    }
+
+    private MyManagedGarden myManagedGarden() {
+        return MyManagedGarden.of(
+                1L,
+                LocalDate.of(2023, 12, 12),
+                LocalDate.of(2023, 12, 13),
+                1L,
+                "https://kr.object.ncloudstorage.com/every-garden/images/garden/view.jpg",
+                1L
+        );
+    }
+
+}

--- a/core/src/test/java/com/garden/back/garden/service/GardenCommandServiceTest.java
+++ b/core/src/test/java/com/garden/back/garden/service/GardenCommandServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -66,7 +67,7 @@ class GardenCommandServiceTest extends IntegrationTestSupport {
 
         // When_Then
         assertThatThrownBy(() -> gardenCommandService.deleteGarden(notExistedGardenDetailParam))
-                .isInstanceOf(EntityNotFoundException.class);
+                .isInstanceOf(EmptyResultDataAccessException.class);
     }
 
     @DisplayName("내가 작성한 텃밭 게시물이 아닌 경우 예외를 던진다.")
@@ -95,7 +96,7 @@ class GardenCommandServiceTest extends IntegrationTestSupport {
 
         // Then
         assertThatThrownBy(() -> gardenRepository.getById(savedPrivateGarden.getGardenId()))
-                .isInstanceOf(JpaObjectRetrievalFailureException.class);
+                .isInstanceOf(EmptyResultDataAccessException.class);
         assertThat(gardenImageRepository.findByGardenId(savedPrivateGarden.getGardenId()).size())
                 .isEqualTo(0);
 

--- a/core/src/test/java/com/garden/back/garden/service/GardenCommandServiceTest.java
+++ b/core/src/test/java/com/garden/back/garden/service/GardenCommandServiceTest.java
@@ -12,13 +12,11 @@ import com.garden.back.garden.service.dto.request.*;
 import com.garden.back.garden.service.recentview.GardenHistoryManager;
 import com.garden.back.global.IntegrationTestSupport;
 import com.garden.back.testutil.garden.GardenFixture;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -249,11 +247,11 @@ class GardenCommandServiceTest extends IntegrationTestSupport {
         given(imageUploader.upload(any(), any())).willReturn(expectedUrl);
 
         MyManagedGarden myManagedGarden = GardenFixture.myManagedGarden(savedPrivateGarden.getGardenId());
-        myManagedGardenRepository.save(myManagedGarden);
+        MyManagedGarden savedMyManagedGarden = myManagedGardenRepository.save(myManagedGarden);
         MyManagedGardenUpdateParam myManagedGardenUpdateParam = GardenFixture.myManagedGardenUpdateParam(
                 expectedUrl,
                 savedPublicGarden.getGardenId(),
-                myManagedGarden.getMyManagedGardenId()
+                savedMyManagedGarden.getMyManagedGardenId()
         );
 
         // When


### PR DESCRIPTION
## 내용
Garden 관련 도메인과 엔티티 분리 
![image](https://github.com/everyone-s-garden/everyonesgarden-v2/assets/108210958/e0c497fd-2fd6-4d3f-88b7-53aa2a8cdbae)

- 장점
  -  DB에 의존적인 객체와 비즈니스 로직을 가지고 있는 객체를 분리 -> 좀 더 책임과 역할이 명확
  - 요구사항에 따라 자주 바뀌는 부분과 RDBMS 특성상 스키마가 잘 바뀌지 않는 부분을 분리 -> 변화가 전파되지 않음
- 단점
  - 변경감지를 사용하지 못함

레파지토리 구조 변경
- 상속에서 합성으로 구조 변경