### PR TITLE
feat: 인기글 기능 추가 및 속닥속닥 게시글 타입 추가

### DIFF
--- a/api/src/docs/asciidoc/post/post.adoc
+++ b/api/src/docs/asciidoc/post/post.adoc
@@ -203,3 +203,17 @@ include::{snippets}/get-my-likes-posts/query-parameters.adoc[]
 ==== Response (Success)
 include::{snippets}/get-my-likes-posts/http-response.adoc[]
 
+[[get-popular-posts]]
+=== 인기 게시글 조회
+
+인기게시글 조회 API는 인기게시글의 정보를 조회하는 기능을 제공합니다.
+예를 들어 offset이 0, limit이 10이면 0번째 게시글부터 10개를 조회하게 됩니다. offset이 10, limit이 5면 10번 째 게시글부터 5개를 조회합니다.
+hour이 1이면 최근 1시간을 기준으로 인기 게시글, hour가 2면 최근 2시간을 기준으로 인기 게시글을 조회합니다.
+
+==== Request
+include::{snippets}/get-popular-posts/http-request.adoc[]
+include::{snippets}/get-popular-posts/query-parameters.adoc[]
+
+==== Response (Success)
+include::{snippets}/get-popular-posts/http-response.adoc[]
+include::{snippets}/get-popular-posts/response-fields.adoc[]

--- a/api/src/main/java/com/garden/back/post/PostController.java
+++ b/api/src/main/java/com/garden/back/post/PostController.java
@@ -3,6 +3,7 @@ package com.garden.back.post;
 import com.garden.back.global.LocationBuilder;
 import com.garden.back.global.loginuser.CurrentUser;
 import com.garden.back.global.loginuser.LoginUser;
+import com.garden.back.post.domain.repository.response.FindAllPopularPostsResponse;
 import com.garden.back.post.domain.repository.response.FindAllPostsResponse;
 import com.garden.back.post.domain.repository.response.FindPostDetailsResponse;
 import com.garden.back.post.domain.repository.response.FindPostsAllCommentResponse;
@@ -173,4 +174,11 @@ public class PostController {
         return ResponseEntity.noContent().build();
     }
 
+    //실시간 인기 게시글 조회
+    @GetMapping(value = "/popular", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<FindAllPopularPostsResponse> getPopularPosts(
+        @ModelAttribute @Valid FindAllPopularPostsRequest request
+    ) {
+        return ResponseEntity.ok(postQueryService.findAllPopularPosts(request.toRepositoryRequest()));
+    }
 }

--- a/api/src/main/java/com/garden/back/post/request/FindAllPopularPostsRequest.java
+++ b/api/src/main/java/com/garden/back/post/request/FindAllPopularPostsRequest.java
@@ -1,0 +1,20 @@
+package com.garden.back.post.request;
+
+import com.garden.back.post.domain.repository.request.FindAllPopularRepositoryPostsRequest;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record FindAllPopularPostsRequest(
+    @PositiveOrZero(message = "0 이상의 정수만 입력해 주세요")
+    Long offset,
+
+    @Positive(message = "양수를 입력해 주세요.")
+    Long limit,
+
+    @Positive(message = "양수를 입력해 주세요.")
+    Integer hour
+) {
+    public FindAllPopularRepositoryPostsRequest toRepositoryRequest() {
+        return new FindAllPopularRepositoryPostsRequest(offset, limit, hour);
+    }
+}

--- a/api/src/main/java/com/garden/back/post/request/FindAllPostParamRequest.java
+++ b/api/src/main/java/com/garden/back/post/request/FindAllPostParamRequest.java
@@ -1,6 +1,7 @@
 package com.garden.back.post.request;
 
 import com.garden.back.global.validation.EnumValue;
+import com.garden.back.post.domain.PostType;
 import com.garden.back.post.domain.repository.request.FindAllPostParamRepositoryRequest;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -15,12 +16,14 @@ public record FindAllPostParamRequest(
 
     String searchContent,
 
+    PostType postType,
+
     @EnumValue(enumClass = FindAllPostParamRepositoryRequest.OrderBy.class, message = "COMMENT_COUNT, RECENT_DATE, LIKE_COUNT, OLDER_DATE 중 한개를 입력해주세요")
     String orderBy
 
 ) {
     public FindAllPostParamRepositoryRequest toRepositoryDto() {
-        return new FindAllPostParamRepositoryRequest(offset, limit, searchContent, FindAllPostParamRepositoryRequest.OrderBy.valueOf(orderBy));
+        return new FindAllPostParamRepositoryRequest(offset, limit, searchContent, postType, FindAllPostParamRepositoryRequest.OrderBy.valueOf(orderBy));
     }
 
 }

--- a/api/src/main/java/com/garden/back/post/request/PostCreateRequest.java
+++ b/api/src/main/java/com/garden/back/post/request/PostCreateRequest.java
@@ -1,5 +1,7 @@
 package com.garden.back.post.request;
 
+import com.garden.back.global.validation.EnumValue;
+import com.garden.back.post.domain.PostType;
 import com.garden.back.post.service.request.PostCreateServiceRequest;
 import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.constraints.Length;
@@ -13,7 +15,11 @@ public record PostCreateRequest(
     String title,
 
     @NotBlank(message = "내용을 입력해주세요")
-    String content
+    String content,
+
+    @EnumValue(enumClass = PostType.class, message = "INFORMATION_SHARE, GARDEN_SHOWCASE, QUESTION, ETC 중 하나만 가능합니다.")
+    String postType
+
 ) {
     public PostCreateServiceRequest toServiceRequest(List<MultipartFile> images) {
         if (images == null) {
@@ -24,7 +30,7 @@ public record PostCreateRequest(
             throw new IllegalArgumentException("게시글 한개당 10장의 이미지만 등록할 수 있습니다.");
         }
 
-        return new PostCreateServiceRequest(title, content, images);
+        return new PostCreateServiceRequest(title, content, PostType.valueOf(postType), images);
     }
 
 }

--- a/api/src/main/java/com/garden/back/post/request/PostUpdateRequest.java
+++ b/api/src/main/java/com/garden/back/post/request/PostUpdateRequest.java
@@ -1,5 +1,7 @@
 package com.garden.back.post.request;
 
+import com.garden.back.global.validation.EnumValue;
+import com.garden.back.post.domain.PostType;
 import com.garden.back.post.service.request.PostUpdateServiceRequest;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -9,7 +11,10 @@ import java.util.List;
 public record PostUpdateRequest(
     String title,
     String content,
-    List<String> deleteImages
+    List<String> deleteImages,
+
+    @EnumValue(enumClass = PostType.class)
+    String postType
 ) {
 
     public PostUpdateServiceRequest toServiceDto(List<MultipartFile> images) {
@@ -17,6 +22,6 @@ public record PostUpdateRequest(
             images = new ArrayList<>();
         }
 
-        return new PostUpdateServiceRequest(images, title, content, deleteImages);
+        return new PostUpdateServiceRequest(images, title, content, deleteImages, PostType.valueOf(postType));
     }
 }

--- a/core/src/main/java/com/garden/back/post/domain/PostType.java
+++ b/core/src/main/java/com/garden/back/post/domain/PostType.java
@@ -1,0 +1,8 @@
+package com.garden.back.post.domain;
+
+public enum PostType {
+    INFORMATION_SHARE,
+    GARDEN_SHOWCASE,
+    QUESTION,
+    ETC
+}

--- a/core/src/main/java/com/garden/back/post/domain/repository/PostCommandRepositoryImpl.java
+++ b/core/src/main/java/com/garden/back/post/domain/repository/PostCommandRepositoryImpl.java
@@ -47,7 +47,7 @@ public class PostCommandRepositoryImpl implements PostCommandRepository {
     @Override
     public void updatePost(PostUpdateRepositoryRequest request) {
         Post post = request.post();
-        post.update(request.title(), request.content(), request.memberId(), request.deleteImages(), request.addedImages());
+        post.update(request.title(), request.content(), request.memberId(), request.deleteImages(), request.addedImages(), request.postType());
     }
 
     @Override

--- a/core/src/main/java/com/garden/back/post/domain/repository/PostQueryRepository.java
+++ b/core/src/main/java/com/garden/back/post/domain/repository/PostQueryRepository.java
@@ -15,4 +15,6 @@ public interface PostQueryRepository {
     FindAllMyPostsResponse findAllMyPosts(Long loginUserId, FindAllMyPostsRepositoryRequest request);
 
     FindAllMyCommentPostsResponse findAllByMyComment(Long loginUserId, FindAllMyCommentPostsRepositoryRequest request);
+
+    FindAllPopularPostsResponse findAllPopularPosts(FindAllPopularRepositoryPostsRequest request);
 }

--- a/core/src/main/java/com/garden/back/post/domain/repository/request/FindAllPopularRepositoryPostsRequest.java
+++ b/core/src/main/java/com/garden/back/post/domain/repository/request/FindAllPopularRepositoryPostsRequest.java
@@ -1,0 +1,8 @@
+package com.garden.back.post.domain.repository.request;
+
+public record FindAllPopularRepositoryPostsRequest(
+    Long offset,
+    Long limit,
+    Integer hour
+) {
+}

--- a/core/src/main/java/com/garden/back/post/domain/repository/request/FindAllPostParamRepositoryRequest.java
+++ b/core/src/main/java/com/garden/back/post/domain/repository/request/FindAllPostParamRepositoryRequest.java
@@ -1,9 +1,12 @@
 package com.garden.back.post.domain.repository.request;
 
+import com.garden.back.post.domain.PostType;
+
 public record FindAllPostParamRepositoryRequest(
     Integer offset,
     Integer limit,
     String searchContent,
+    PostType postType,
     OrderBy orderBy
 ) {
 

--- a/core/src/main/java/com/garden/back/post/domain/repository/request/PostUpdateRepositoryRequest.java
+++ b/core/src/main/java/com/garden/back/post/domain/repository/request/PostUpdateRepositoryRequest.java
@@ -1,6 +1,7 @@
 package com.garden.back.post.domain.repository.request;
 
 import com.garden.back.post.domain.Post;
+import com.garden.back.post.domain.PostType;
 
 import java.util.List;
 
@@ -10,5 +11,6 @@ public record PostUpdateRepositoryRequest(
     List<String> addedImages,
     String title,
     String content,
-    List<String> deleteImages
+    List<String> deleteImages,
+    PostType postType
 ) {}

--- a/core/src/main/java/com/garden/back/post/domain/repository/response/FindAllPopularPostsResponse.java
+++ b/core/src/main/java/com/garden/back/post/domain/repository/response/FindAllPopularPostsResponse.java
@@ -1,0 +1,19 @@
+package com.garden.back.post.domain.repository.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record FindAllPopularPostsResponse(
+    List<PostInfo> postInfos
+) {
+    public record PostInfo(
+        Long postId,
+        String title,
+        Long likeCount,
+        Long commentCount,
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate createdDate
+    ) {}
+}

--- a/core/src/main/java/com/garden/back/post/service/PostQueryService.java
+++ b/core/src/main/java/com/garden/back/post/service/PostQueryService.java
@@ -37,4 +37,8 @@ public class PostQueryService {
     public FindAllMyCommentPostsResponse findAllByMyComment(Long loginUserId, FindAllMyCommentPostsRepositoryRequest request) {
         return postQueryRepository.findAllByMyComment(loginUserId, request);
     }
+
+    public FindAllPopularPostsResponse findAllPopularPosts(FindAllPopularRepositoryPostsRequest request) {
+        return postQueryRepository.findAllPopularPosts(request);
+    }
 }

--- a/core/src/main/java/com/garden/back/post/service/request/PostCreateServiceRequest.java
+++ b/core/src/main/java/com/garden/back/post/service/request/PostCreateServiceRequest.java
@@ -1,6 +1,7 @@
 package com.garden.back.post.service.request;
 
 import com.garden.back.post.domain.Post;
+import com.garden.back.post.domain.PostType;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -8,9 +9,10 @@ import java.util.List;
 public record PostCreateServiceRequest(
     String title,
     String content,
+    PostType postType,
     List<MultipartFile> images
 ) {
     public Post toEntity(Long postAuthorId, List<String> postImageUrls) {
-        return Post.create(title, content, postAuthorId, postImageUrls);
+        return Post.create(title, content, postAuthorId, postImageUrls, postType);
     }
 }

--- a/core/src/main/java/com/garden/back/post/service/request/PostUpdateServiceRequest.java
+++ b/core/src/main/java/com/garden/back/post/service/request/PostUpdateServiceRequest.java
@@ -1,6 +1,7 @@
 package com.garden.back.post.service.request;
 
 import com.garden.back.post.domain.Post;
+import com.garden.back.post.domain.PostType;
 import com.garden.back.post.domain.repository.request.PostUpdateRepositoryRequest;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -10,7 +11,8 @@ public record PostUpdateServiceRequest(
     List<MultipartFile> addedImages,
     String title,
     String content,
-    List<String> deleteImages
+    List<String> deleteImages,
+    PostType postType
 ) {
     public Integer addedImagesCount() {
         return addedImages.size();
@@ -21,6 +23,6 @@ public record PostUpdateServiceRequest(
     }
 
     public PostUpdateRepositoryRequest toRepositoryRequest(Post post, Long memberId, List<String> addedImages) {
-        return new PostUpdateRepositoryRequest(post, memberId, addedImages, title, content, deleteImages);
+        return new PostUpdateRepositoryRequest(post, memberId, addedImages, title, content, deleteImages, postType);
     }
 }

--- a/core/src/test/java/com/garden/back/post/domain/PostTest.java
+++ b/core/src/test/java/com/garden/back/post/domain/PostTest.java
@@ -23,7 +23,7 @@ class PostTest {
         List<String> postUrls = new ArrayList<>();
         postUrls.add("http://example.com/image1.jpg");
         postUrls.add("http://example.com/image2.jpg");
-        post = Post.create("Test Title", "Test Content", 1L, postUrls);
+        post = Post.create("Test Title", "Test Content", 1L, postUrls, PostType.QUESTION);
     }
 
     @Test
@@ -44,11 +44,12 @@ class PostTest {
         List<String> deletedUrls = new ArrayList<>();
         deletedUrls.add("http://example.com/image1.jpg");
 
-        post.update("New Title", "New Content", 1L, deletedUrls, newUrls);
+        post.update("New Title", "New Content", 1L, deletedUrls, newUrls, PostType.GARDEN_SHOWCASE);
 
         assertThat(post.getTitle()).isEqualTo("New Title");
         assertThat(post.getContent()).isEqualTo("New Content");
-        assertThat(post.getPostImages()).hasSize(2); // One added, one removed
+        assertThat(post.getPostImages()).hasSize(2);
+        assertThat(post.getPostType()).isEqualTo(PostType.GARDEN_SHOWCASE);
     }
 
     @Test
@@ -122,16 +123,17 @@ class PostTest {
     @ParameterizedTest
     @MethodSource("provideInvalidPostArguments")
     @DisplayName("게시물 생성 시 유효하지 않은 인자 검증")
-    void testInvalidPostCreation(String title, String content, Long postAuthorId) {
-        assertThatThrownBy(() -> Post.create(title, content, postAuthorId, new ArrayList<>()))
+    void testInvalidPostCreation(String title, String content, Long postAuthorId, PostType postType) {
+        assertThatThrownBy(() -> Post.create(title, content, postAuthorId, new ArrayList<>(), postType))
             .isInstanceOf(IllegalArgumentException.class);
     }
 
     private static Stream<Arguments> provideInvalidPostArguments() {
         return Stream.of(
-            Arguments.of("유효한 제목", "", 1L), // Invalid content (blank)
-            Arguments.of("유효하지 않은 제목".repeat(250), "Valid Content", 1L), // Invalid title (too long)
-            Arguments.of("유효한 제목", "Valid Content", -1L) // Invalid postAuthorId (negative)
+            Arguments.of("유효한 제목", "", 1L, PostType.GARDEN_SHOWCASE), // Invalid content (blank)
+            Arguments.of("유효하지 않은 제목".repeat(250), "Valid Content", 1L, PostType.GARDEN_SHOWCASE), // Invalid title (too long)
+            Arguments.of("유효한 제목", "Valid Content", -1L, PostType.GARDEN_SHOWCASE),
+            Arguments.of("유효한 제목", "Valid Content", 1L, null)
         );
     }
 }

--- a/core/src/test/java/com/garden/back/post/service/PostCommandServiceTest.java
+++ b/core/src/test/java/com/garden/back/post/service/PostCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.garden.back.post.service;
 import com.garden.back.global.IntegrationTestSupport;
 import com.garden.back.post.domain.Post;
 import com.garden.back.post.domain.PostComment;
+import com.garden.back.post.domain.PostType;
 import com.garden.back.post.domain.repository.CommentLikeRepository;
 import com.garden.back.post.domain.repository.PostCommentRepository;
 import com.garden.back.post.domain.repository.PostLikeRepository;
@@ -84,7 +85,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
 
         given(imageUploader.upload(any(), any())).willReturn(expectedUrl);
@@ -98,7 +99,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         String expectedTitle = "제목";
         String expectedContent = "내용";
 
-        PostUpdateServiceRequest request = new PostUpdateServiceRequest(List.of(mockMultipartFile), expectedTitle, expectedContent, List.of(expectedUrl));
+        PostUpdateServiceRequest request = new PostUpdateServiceRequest(List.of(mockMultipartFile), expectedTitle, expectedContent, List.of(expectedUrl), PostType.QUESTION);
         //when
         postCommandService.updatePost(savedPostId, memberId, request);
 
@@ -115,7 +116,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
 
         //when
@@ -131,7 +132,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
 
         //when & then
@@ -147,7 +148,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
         Long expectedLikeCount = 1L;
 
@@ -165,7 +166,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
         Long expectedLikeCount = 1L;
 
@@ -186,7 +187,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
         PostComment postComment = PostComment.create(null, memberId, "댓글내용", savedPostId);
         Long savedParentId = postCommentRepository.save(postComment).getId();
@@ -210,7 +211,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
         PostComment postComment = PostComment.create(null, memberId, "댓글내용", savedPostId);
         Long savedParentId = postCommentRepository.save(postComment).getId();
@@ -270,7 +271,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
 
         CommentCreateServiceRequest request = new CommentCreateServiceRequest("제목", null);
@@ -371,7 +372,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
 
         //when
@@ -390,7 +391,7 @@ class PostCommandServiceTest extends IntegrationTestSupport {
         //given
         Long memberId = 1L;
         String expectedUrl = "https://kr.object.ncloudstorage.com/every-garden/images/feedback/download.jpg";
-        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl));
+        Post post = Post.create("asdf", "asdf", memberId, List.of(expectedUrl), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
 
         //when & then

--- a/core/src/test/java/com/garden/back/post/service/PostQueryServiceTest.java
+++ b/core/src/test/java/com/garden/back/post/service/PostQueryServiceTest.java
@@ -6,6 +6,7 @@ import com.garden.back.member.repository.MemberRepository;
 import com.garden.back.member.Role;
 import com.garden.back.post.domain.Post;
 import com.garden.back.post.domain.PostComment;
+import com.garden.back.post.domain.PostType;
 import com.garden.back.post.domain.repository.PostCommentRepository;
 import com.garden.back.post.domain.repository.PostRepository;
 import com.garden.back.post.domain.repository.request.*;
@@ -48,7 +49,7 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         String imageUrl = "http://example.com/image.jpg";
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
-        Post post = Post.create(title, content, savedMemberId, List.of(imageUrl));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         Post savedPost = postRepository.save(post);
 
         FindPostDetailsResponse response = new FindPostDetailsResponse(0L, 0L, nickname, content, title, savedPost.getCreatedDate(), List.of(imageUrl));
@@ -67,11 +68,11 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
 
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         post.increaseLikeCount(); // 좋아요 수 많음, 더 최근 게시글
         Long savedPostId1 = postRepository.save(post).getId();
 
-        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         post2.increaseCommentCount(); //댓글 수 많음, 더 늦은 게시글
         Long savedPostId2 = postRepository.save(post2).getId();
 
@@ -80,7 +81,36 @@ class PostQueryServiceTest extends IntegrationTestSupport {
             new FindAllPostsResponse.PostInfo(savedPostId1, title, post.getLikesCount(), post.getCommentsCount(), post.getCreatedDate()) //Post2가 댓글 더 많음
         );
 
-        FindAllPostParamRepositoryRequest request = new FindAllPostParamRepositoryRequest(0, 10, title, FindAllPostParamRepositoryRequest.OrderBy.COMMENT_COUNT);
+        FindAllPostParamRepositoryRequest request = new FindAllPostParamRepositoryRequest(0, 10, title, PostType.QUESTION, FindAllPostParamRepositoryRequest.OrderBy.COMMENT_COUNT);
+
+        //when & then
+        FindAllPostsResponse expectedResponseForCommentCount = new FindAllPostsResponse(postInfosForCommentCount);
+        assertThat(postQueryService.findAllPosts(request)).isEqualTo(expectedResponseForCommentCount);
+    }
+
+    @DisplayName("모든 게시글을 게시글 타입으로 조회할 수 있다.")
+    @Test
+    void findAllPostsByPostType() {
+        //given
+        String content = "내용";
+        String nickname = "닉네임";
+        String title = "제목";
+        Member member = Member.create("asdf@example.com", nickname, Role.USER);
+        Long savedMemberId = memberRepository.save(member).getId();
+
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
+        post.increaseLikeCount(); // 좋아요 수 많음, 더 최근 게시글
+        Long savedPostId1 = postRepository.save(post).getId();
+
+        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.ETC);
+        post2.increaseCommentCount(); //댓글 수 많음, 더 늦은 게시글
+        Long savedPostId2 = postRepository.save(post2).getId();
+
+        List<FindAllPostsResponse.PostInfo> postInfosForCommentCount = List.of(
+            new FindAllPostsResponse.PostInfo(savedPostId1, title, post.getLikesCount(), post.getCommentsCount(), post.getCreatedDate()) //Post2가 댓글 더 많음
+        );
+
+        FindAllPostParamRepositoryRequest request = new FindAllPostParamRepositoryRequest(0, 10, title, PostType.QUESTION, FindAllPostParamRepositoryRequest.OrderBy.COMMENT_COUNT);
 
         //when & then
         FindAllPostsResponse expectedResponseForCommentCount = new FindAllPostsResponse(postInfosForCommentCount);
@@ -97,20 +127,20 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
 
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         post.increaseLikeCount(); // 좋아요 수 많음, 더 최근 게시글
         Long savedPostId1 = postRepository.save(post).getId();
 
-        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         post2.increaseCommentCount(); //댓글 수 많음, 더 늦은 게시글
         Long savedPostId2 = postRepository.save(post2).getId();
 
         List<FindAllPostsResponse.PostInfo> postInfosForCommentCount = List.of(
-            new FindAllPostsResponse.PostInfo(savedPostId1, title, post.getLikesCount(), post.getCommentsCount(),post.getCreatedDate()), //Post가 댓글 더 많음
+            new FindAllPostsResponse.PostInfo(savedPostId1, title, post.getLikesCount(), post.getCommentsCount(), post.getCreatedDate()), //Post가 댓글 더 많음
             new FindAllPostsResponse.PostInfo(savedPostId2, title, post2.getLikesCount(), post2.getCommentsCount(), post2.getCreatedDate())
         );
 
-        FindAllPostParamRepositoryRequest request = new FindAllPostParamRepositoryRequest(0, 10, title, FindAllPostParamRepositoryRequest.OrderBy.LIKE_COUNT);
+        FindAllPostParamRepositoryRequest request = new FindAllPostParamRepositoryRequest(0, 10, title, PostType.QUESTION, FindAllPostParamRepositoryRequest.OrderBy.LIKE_COUNT);
 
         //when & then
         FindAllPostsResponse expectedResponseForCommentCount = new FindAllPostsResponse(postInfosForCommentCount);
@@ -127,21 +157,21 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
 
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         post.increaseLikeCount(); // 좋아요 수 많음, 더 최근 게시글
         Long savedPostId1 = postRepository.save(post).getId();
 
-        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         post2.increaseCommentCount(); //댓글 수 많음, 더 늦은 게시글
         Long savedPostId2 = postRepository.save(post2).getId();
 
         List<FindAllPostsResponse.PostInfo> postInfosForCommentCount = List.of(
-            new FindAllPostsResponse.PostInfo(savedPostId2, title, post2.getLikesCount(), post2.getCommentsCount(),post2.getCreatedDate()),
+            new FindAllPostsResponse.PostInfo(savedPostId2, title, post2.getLikesCount(), post2.getCommentsCount(), post2.getCreatedDate()),
             new FindAllPostsResponse.PostInfo(savedPostId1, title, post.getLikesCount(), post.getCommentsCount(), post.getCreatedDate()) //Post가 더 오래 됨
 
         );
 
-        FindAllPostParamRepositoryRequest request = new FindAllPostParamRepositoryRequest(0, 10, null, FindAllPostParamRepositoryRequest.OrderBy.RECENT_DATE);
+        FindAllPostParamRepositoryRequest request = new FindAllPostParamRepositoryRequest(0, 10, null, PostType.QUESTION, FindAllPostParamRepositoryRequest.OrderBy.RECENT_DATE);
 
         //when & then
         FindAllPostsResponse expectedResponseForCommentCount = new FindAllPostsResponse(postInfosForCommentCount);
@@ -158,11 +188,11 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
 
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         post.increaseLikeCount(); // 좋아요 수 많음, 더 최근 게시글
         Long savedPostId1 = postRepository.save(post).getId();
 
-        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         post2.increaseCommentCount(); //댓글 수 많음, 더 늦은 게시글
         Long savedPostId2 = postRepository.save(post2).getId();
 
@@ -171,7 +201,7 @@ class PostQueryServiceTest extends IntegrationTestSupport {
             new FindAllPostsResponse.PostInfo(savedPostId2, title, post2.getLikesCount(), post2.getCommentsCount(), post2.getCreatedDate())
         );
 
-        FindAllPostParamRepositoryRequest request = new FindAllPostParamRepositoryRequest(0, 10, title, FindAllPostParamRepositoryRequest.OrderBy.OLDER_DATE);
+        FindAllPostParamRepositoryRequest request = new FindAllPostParamRepositoryRequest(0, 10, title, PostType.QUESTION, FindAllPostParamRepositoryRequest.OrderBy.OLDER_DATE);
 
         //when & then
         FindAllPostsResponse expectedResponseForCommentCount = new FindAllPostsResponse(postInfosForCommentCount);
@@ -188,7 +218,7 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
 
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
         PostComment postComment = PostComment.create(null, savedMemberId, content, savedPostId);
         Long olderCommentId = postCommentRepository.save(postComment).getId();
@@ -218,7 +248,7 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
 
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
         PostComment postComment = PostComment.create(null, savedMemberId, content, savedPostId);
         Long haveLessCommentLikeId = postCommentRepository.save(postComment).getId();
@@ -248,7 +278,7 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
 
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         Long savedPostId = postRepository.save(post).getId();
         PostComment postComment = PostComment.create(null, savedMemberId, content, savedPostId);
         Long olderCommentId = postCommentRepository.save(postComment).getId();
@@ -278,7 +308,7 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         String title = "제목";
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         postRepository.save(post);
         postCommandService.addLikeToPost(post.getId(), member.getId());
         FindAllMyLikePostsResponse expected = new FindAllMyLikePostsResponse(List.of(new FindAllMyLikePostsResponse.PostInfo(post.getId(), post.getTitle())));
@@ -298,7 +328,7 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         String title = "제목";
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         postRepository.save(post);
         FindAllMyPostsResponse expected = new FindAllMyPostsResponse(List.of(new FindAllMyPostsResponse.PostInfo(post.getId(), post.getTitle())));
 
@@ -318,7 +348,7 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         String title = "제목";
         Member member = Member.create("asdf@example.com", nickname, Role.USER);
         Long savedMemberId = memberRepository.save(member).getId();
-        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"));
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         postRepository.save(post);
         postCommandService.createComment(post.getId(), member.getId(), new CommentCreateServiceRequest("내용", null));
         FindAllMyCommentPostsResponse expected = new FindAllMyCommentPostsResponse(List.of(new FindAllMyCommentPostsResponse.PostInfo(post.getId(), post.getTitle())));
@@ -326,5 +356,32 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         //when & then
         FindAllMyCommentPostsResponse actual = postQueryService.findAllByMyComment(member.getId(), new FindAllMyCommentPostsRepositoryRequest(0L, 10L));
         assertThat(expected).isEqualTo(actual);
+    }
+
+    @DisplayName("실시간 인기 게시글을 조회한다.")
+    @Test
+    void findPopularPosts() {
+        //given
+        String content = "내용";
+        String nickname = "닉네임";
+        String title = "제목";
+        Member member = Member.create("asdf@example.com", nickname, Role.USER);
+        Long savedMemberId = memberRepository.save(member).getId();
+
+        Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
+        post.increaseLikeCount(); // 좋아요 수 많음
+        Long savedPostId1 = postRepository.save(post).getId();
+
+        Post post2 = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
+        post2.increaseCommentCount(); //댓글 수 많음
+        Long savedPostId2 = postRepository.save(post2).getId();
+
+        //when & then
+        FindAllPopularRepositoryPostsRequest request = new FindAllPopularRepositoryPostsRequest(0L, 10L, 1);
+        FindAllPopularPostsResponse response = new FindAllPopularPostsResponse(List.of(
+            new FindAllPopularPostsResponse.PostInfo(savedPostId1, title, post.getLikesCount(), post.getCommentsCount(), post.getCreatedDate()),
+            new FindAllPopularPostsResponse.PostInfo(savedPostId2, title, post2.getLikesCount(), post2.getCommentsCount(), post2.getCreatedDate())
+        ));
+        assertThat(postQueryService.findAllPopularPosts(request)).isEqualTo(response);
     }
 }

--- a/core/src/test/java/com/garden/back/report/service/ReportServiceTest.java
+++ b/core/src/test/java/com/garden/back/report/service/ReportServiceTest.java
@@ -7,6 +7,7 @@ import com.garden.back.crop.domain.repository.CropJpaRepository;
 import com.garden.back.global.IntegrationTestSupport;
 import com.garden.back.post.domain.Post;
 import com.garden.back.post.domain.PostComment;
+import com.garden.back.post.domain.PostType;
 import com.garden.back.post.domain.repository.PostCommentRepository;
 import com.garden.back.post.domain.repository.PostRepository;
 import com.garden.back.report.domain.comment.CommentReport;
@@ -154,7 +155,7 @@ class ReportServiceTest extends IntegrationTestSupport {
     @Test
     void reportPost() {
         //given
-        Post post = Post.create("제목", "내용", 1L, List.of("https://abc.com"));
+        Post post = Post.create("제목", "내용", 1L, List.of("https://abc.com"), PostType.QUESTION);
         postRepository.save(post);
 
         //when
@@ -170,7 +171,7 @@ class ReportServiceTest extends IntegrationTestSupport {
     @Test
     void reportPostInvalid() {
         //given
-        Post post = Post.create("제목", "내용", 1L, List.of("https://abc.com"));
+        Post post = Post.create("제목", "내용", 1L, List.of("https://abc.com"), PostType.QUESTION);
         postRepository.save(post);
 
         //when & then


### PR DESCRIPTION
## 내용
댓글은 1점, 좋아요는 3점을 부과하여 인기 글의 기준을 정했습니다.
시간을 파라미터로 받아 최근 n시간 만큼의 게시글 중 부과된 점수에 기준을 맞춰 조회가 되도록 했습니다.

## 테스트 방법


## 추가 정보
이 PR과 관련된 추가적인 정보가 있다면 여기에 적어주세요.
