### PR TITLE
refactor : 채팅 세션 Id 얻기

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -29,8 +29,8 @@ dependencies {
 
     //Socket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
-    implementation group: 'org.webjars', name: 'sockjs-client', version: '1.5.1'
-    implementation group: 'org.webjars', name: 'stomp-websocket', version: '2.3.4'
+    implementation 'org.webjars:sockjs-client:1.5.1'
+    implementation 'org.springframework.security:spring-security-messaging'
 
     // spatial type
     implementation 'org.hibernate:hibernate-spatial:6.3.1.Final'

--- a/api/src/docs/asciidoc/chat/chats.adoc
+++ b/api/src/docs/asciidoc/chat/chats.adoc
@@ -23,18 +23,6 @@ include::{snippets}/enter-garden-chat-room/path-parameters.adoc[]
 include::{snippets}/enter-garden-chat-room/http-response.adoc[]
 
 
-=== 텃밭 채팅 세션 등록
-현재 채팅의 세션을 등록해야 채팅방에 접속해 있는 유저를 판단할 수 있습니다. +
-이 정보는 읽음 처리를 처리할 때 사용됩니다.
-
-==== Request
-include::{snippets}/create-garden-chat-session/http-request.adoc[]
-include::{snippets}/create-garden-chat-session/request-fields.adoc[]
-
-==== Response (Success)
-include::{snippets}/create-garden-chat-session/http-response.adoc[]
-
-
 === 텃밭 채팅방 삭제
 텃밭 채팅방을 삭제할 수 있습니다. +
 그러나 대화를 나누고 있는 상대방의 채팅방은 남아있게 됩니다.

--- a/api/src/main/java/com/garden/back/auth/config/SecurityConfig.java
+++ b/api/src/main/java/com/garden/back/auth/config/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://everyonesgarden.vercel.app/"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000", "https://everyonesgarden.vercel.app/","https://jxy.me"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/api/src/main/java/com/garden/back/auth/jwt/JwtAuthenticationFilter.java
+++ b/api/src/main/java/com/garden/back/auth/jwt/JwtAuthenticationFilter.java
@@ -46,16 +46,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         HttpServletResponse response,
         FilterChain filterChain
     ) throws ServletException, IOException {
-
         String jwt = resolveToken(request);
-
         if (StringUtils.hasText(jwt)) {
             Claims claims = resolveClaims(jwt, response);
             if (claims == null) {
-                log.info("claims null");
                 return;
             }
-
             updateSecurityContext(claims, jwt);
         }
         filterChain.doFilter(request, response);
@@ -67,7 +63,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String role = claims.get(jwtProperties.getAuthorityKey(), String.class);
         UserDetails principal = SecurityUser.of(memberId, role);
         Authentication authentication = new UsernamePasswordAuthenticationToken(principal, jwt, principal.getAuthorities());
-        log.info("authentication: {}", authentication.getName());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 

--- a/api/src/main/java/com/garden/back/chat/event/WebSocketListenerConfig.java
+++ b/api/src/main/java/com/garden/back/chat/event/WebSocketListenerConfig.java
@@ -1,0 +1,72 @@
+package com.garden.back.chat.event;
+
+import com.garden.back.garden.repository.chatentry.SessionId;
+import com.garden.back.garden.service.GardenChatRoomService;
+import com.garden.back.garden.service.GardenChatService;
+import com.garden.back.garden.service.dto.request.GardenSessionCreateParam;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.AbstractSubProtocolEvent;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+
+import java.util.Map;
+
+@Component
+public class WebSocketListenerConfig {
+
+    private static final String SUBSCRIBE_URL="/queue/garden-chats/";
+    private final GardenChatService gardenChatService;
+    private final GardenChatRoomService gardenChatRoomService;
+
+    public WebSocketListenerConfig(GardenChatService gardenChatService, GardenChatRoomService gardenChatRoomService) {
+        this.gardenChatService = gardenChatService;
+        this.gardenChatRoomService = gardenChatRoomService;
+    }
+
+    @EventListener
+    public void onDisconnectEvent(SessionDisconnectEvent event) {
+        gardenChatService.leaveChatRoom(SessionId.of(event.getSessionId()));
+    }
+
+    @EventListener(SessionConnectEvent.class)
+    public void onConnect(SessionConnectEvent event) {
+        String sessionId = getSessionId(event);
+        Long memberId = getMemberId(event);
+        gardenChatService.saveSocketInfo(sessionId, memberId);
+    }
+
+    @EventListener(SessionSubscribeEvent.class)
+    public void onSubscribe(SessionSubscribeEvent event) {
+        String sessionId = getSessionId(event);
+        Long roomId = getRoomId(event);
+        Long memberId = gardenChatService.getWebSocketInfo(sessionId);
+
+        gardenChatRoomService.createSessionInfo(
+            new GardenSessionCreateParam(
+                SessionId.of(sessionId),
+                roomId,
+                memberId
+            )
+        );
+    }
+
+    private String getSessionId(AbstractSubProtocolEvent event) {
+        return event.getMessage().getHeaders().get("simpSessionId").toString();
+    }
+
+    private Long getMemberId(AbstractSubProtocolEvent event) {
+        String memberId = event.getMessage().getHeaders().get("nativeHeaders", Map.class)
+            .get("memberId")
+            .toString()
+            .replaceAll("[\\[\\]]", ""); // Remove square brackets
+        return Long.parseLong(memberId);
+    }
+
+    private Long getRoomId(AbstractSubProtocolEvent event) {
+        String destination = event.getMessage().getHeaders().get("simpDestination", String.class);
+        return Long.parseLong(destination.replace(SUBSCRIBE_URL, ""));
+    }
+
+}

--- a/api/src/main/java/com/garden/back/chat/gardenchat/controller/GardenChatController.java
+++ b/api/src/main/java/com/garden/back/chat/gardenchat/controller/GardenChatController.java
@@ -8,26 +8,23 @@ import com.garden.back.chat.gardenchat.controller.dto.response.GardenMessageSend
 import com.garden.back.chat.gardenchat.facade.ChatRoomFacade;
 import com.garden.back.chat.gardenchat.facade.GardenChatRoomsFindFacadeRequest;
 import com.garden.back.chat.gardenchat.facade.GardenChatRoomsFindFacadeResponses;
-import com.garden.back.garden.repository.chatentry.SessionId;
 import com.garden.back.garden.service.GardenChatService;
 import com.garden.back.garden.service.dto.response.GardenChatMessagesGetResults;
 import com.garden.back.global.loginuser.CurrentUser;
 import com.garden.back.global.loginuser.LoginUser;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.annotation.SendToUser;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.messaging.handler.annotation.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
-@RestController
+@Controller
 public class GardenChatController {
 
     private final GardenChatService gardenChatService;
@@ -38,52 +35,53 @@ public class GardenChatController {
         this.chatRoomFacade = chatRoomFacade;
     }
 
-    @MessageMapping("/garden-chats/{roomId}/")
-    @SendToUser("/queue/garden-chats/{roomId}")
+    @MessageMapping("/garden-chats/{roomId}")
+    @SendTo("/queue/garden-chats/{roomId}")
     public GardenMessageSendResponse sendMessage(
-            @DestinationVariable("roomId") Long roomId,
-            @CurrentUser LoginUser loginUser,
-            @Payload @Valid GardenMessageSendRequest request) {
-        return GardenMessageSendResponse.to(gardenChatService.saveMessage(request.to(loginUser, roomId)));
-    }
+        @DestinationVariable("roomId") Long roomId,
+        Authentication  authentication,
+        @Payload GardenMessageSendRequest request,
+        @Header("simpSessionId") String sessionId) {
 
-    @EventListener
-    public void onDisconnectEvent(SessionDisconnectEvent event) {
-        gardenChatService.leaveChatRoom(SessionId.of(event.getSessionId()));
+        return GardenMessageSendResponse.to(gardenChatService.saveMessage(
+            request.to(
+                authentication.getName(),
+                roomId,
+                sessionId)));
     }
 
     @GetMapping(
-            path = "/garden-chats/{roomId}/messages",
-            produces = MediaType.APPLICATION_JSON_VALUE
+        path = "/garden-chats/{roomId}/messages",
+        produces = MediaType.APPLICATION_JSON_VALUE
     )
     public ResponseEntity<GardenChatMessageGetResponses> getGardenChatMessages(
-            @PathVariable @Positive Long roomId,
-            @CurrentUser LoginUser loginUser,
-            @RequestParam @NotNull Integer pageNumber
+        @PathVariable @Positive Long roomId,
+        @CurrentUser LoginUser loginUser,
+        @RequestParam @NotNull Integer pageNumber
     ) {
         GardenChatMessagesGetResults chatRoomMessages = gardenChatService.getChatRoomMessages(
-                GardenChatMessagesGetRequest.to(loginUser, roomId, pageNumber)
+            GardenChatMessagesGetRequest.to(loginUser, roomId, pageNumber)
         );
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(GardenChatMessageGetResponses.to(chatRoomMessages));
+            .body(GardenChatMessageGetResponses.to(chatRoomMessages));
     }
 
     @GetMapping(
-            path = "/garden-chats",
-            produces = MediaType.APPLICATION_JSON_VALUE
+        path = "/garden-chats",
+        produces = MediaType.APPLICATION_JSON_VALUE
     )
     public ResponseEntity<GardenChatRoomsFindResponses> findChatRoomsInMember(
-            @RequestParam @NotNull Integer pageNumber,
-            @CurrentUser LoginUser loginUser
-    ){
+        @RequestParam @NotNull Integer pageNumber,
+        @CurrentUser LoginUser loginUser
+    ) {
         GardenChatRoomsFindFacadeResponses chatRoomsInMember = chatRoomFacade.findChatRoomsInMember(GardenChatRoomsFindFacadeRequest.of(
-                loginUser,
-                pageNumber
+            loginUser,
+            pageNumber
         ));
 
         return ResponseEntity.status(HttpStatus.OK)
-                        .body(GardenChatRoomsFindResponses.to(chatRoomsInMember));
+            .body(GardenChatRoomsFindResponses.to(chatRoomsInMember));
     }
 
 }

--- a/api/src/main/java/com/garden/back/chat/gardenchat/controller/GardenChatController.java
+++ b/api/src/main/java/com/garden/back/chat/gardenchat/controller/GardenChatController.java
@@ -19,12 +19,12 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.*;
 import org.springframework.security.core.Authentication;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 public class GardenChatController {
 
     private final GardenChatService gardenChatService;

--- a/api/src/main/java/com/garden/back/chat/gardenchat/controller/GardenChatRoomController.java
+++ b/api/src/main/java/com/garden/back/chat/gardenchat/controller/GardenChatRoomController.java
@@ -2,7 +2,6 @@ package com.garden.back.chat.gardenchat.controller;
 
 import com.garden.back.chat.gardenchat.controller.dto.request.GardenChatReportRequest;
 import com.garden.back.chat.gardenchat.controller.dto.request.GardenChatRoomCreateRequest;
-import com.garden.back.chat.gardenchat.controller.dto.request.GardenSessionCreateRequest;
 import com.garden.back.chat.gardenchat.controller.dto.response.GardenChatReportResponse;
 import com.garden.back.chat.gardenchat.controller.dto.response.GardenChatRoomEnterResponse;
 import com.garden.back.chat.gardenchat.facade.ChatRoomFacade;
@@ -61,18 +60,6 @@ public class GardenChatRoomController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(GardenChatRoomEnterResponse.to(
                         chatRoomFacade.enterGardenChatRoom(request)));
-    }
-
-    @PostMapping(
-            path = "/sessions",
-            consumes = MediaType.APPLICATION_JSON_VALUE
-    )
-    public ResponseEntity<Void> createSession(
-            @RequestBody @Valid GardenSessionCreateRequest request,
-            @CurrentUser LoginUser loginUser
-    ) {
-        gardenChatRoomService.createSessionInfo(request.to(loginUser));
-        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @DeleteMapping(

--- a/api/src/main/java/com/garden/back/chat/gardenchat/controller/dto/request/GardenMessageSendRequest.java
+++ b/api/src/main/java/com/garden/back/chat/gardenchat/controller/dto/request/GardenMessageSendRequest.java
@@ -1,19 +1,20 @@
 package com.garden.back.chat.gardenchat.controller.dto.request;
 
-import com.garden.back.global.loginuser.LoginUser;
 import com.garden.back.garden.repository.chatentry.SessionId;
 import com.garden.back.garden.service.dto.request.GardenChatMessageSendParam;
 
 public record GardenMessageSendRequest(
-        SessionId sessionId,
-        String content
+    String content
 ) {
-    public GardenChatMessageSendParam to(LoginUser loginUser, Long roomId) {
+    public GardenChatMessageSendParam to(
+        String memberId,
+        Long roomId,
+        String sessionId) {
         return new GardenChatMessageSendParam(
-                sessionId,
-                loginUser.memberId(),
-                roomId,
-                content
+            SessionId.of(sessionId),
+            Long.parseLong(memberId),
+            roomId,
+            content
         );
     }
 }

--- a/api/src/main/java/com/garden/back/global/SocketConfig.java
+++ b/api/src/main/java/com/garden/back/global/SocketConfig.java
@@ -29,8 +29,7 @@ public class SocketConfig implements WebSocketMessageBrokerConfigurer {
         registry
                 .setErrorHandler(chatErrorHandler)
                 .addEndpoint("/ws/connect")
-                .setAllowedOriginPatterns("*")
-                .withSockJS();
+                .setAllowedOriginPatterns("*");
     }
 
     @Override

--- a/api/src/test/java/com/garden/back/docs/chat/garden/ChatDocsTest.java
+++ b/api/src/test/java/com/garden/back/docs/chat/garden/ChatDocsTest.java
@@ -3,7 +3,6 @@ package com.garden.back.docs.chat.garden;
 import com.garden.back.chat.gardenchat.controller.GardenChatRoomController;
 import com.garden.back.chat.gardenchat.controller.dto.request.GardenChatReportRequest;
 import com.garden.back.chat.gardenchat.controller.dto.request.GardenChatRoomCreateRequest;
-import com.garden.back.chat.gardenchat.controller.dto.request.GardenSessionCreateRequest;
 import com.garden.back.chat.gardenchat.facade.ChatRoomFacade;
 import com.garden.back.chat.gardenchat.facade.GardenChatRoomEnterFacadeResponse;
 import com.garden.back.docs.RestDocsSupport;
@@ -85,22 +84,6 @@ class ChatDocsTest extends RestDocsSupport {
                         )));
     }
 
-    @DisplayName("텃밭 분양 관련 채팅방 세션을 생성할 수 있다.")
-    @Test
-    void createGardenChatSession() throws Exception {
-        GardenSessionCreateRequest gardenSessionCreateRequest = ChatRoomFixture.gardenSessionCreateRequest();
-
-        mockMvc.perform(post("/garden-chats/sessions")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(gardenSessionCreateRequest)))
-                .andDo(print())
-                .andExpect(status().isCreated())
-                .andDo(document("create-garden-chat-session",
-                        requestFields(
-                                fieldWithPath("sessionId").type(JsonFieldType.STRING).description("채팅 세션 아이디"),
-                                fieldWithPath("roomId").type(JsonFieldType.NUMBER).description("채팅방 아이디")
-                        )));
-    }
 
     @DisplayName("텃밭 분양 채팅방을 영구적으로 삭제한다.")
     @Test

--- a/chat/src/main/java/com/garden/back/garden/repository/chatentry/garden/GardenChatRoomEntryRepositoryImpl.java
+++ b/chat/src/main/java/com/garden/back/garden/repository/chatentry/garden/GardenChatRoomEntryRepositoryImpl.java
@@ -1,13 +1,13 @@
 package com.garden.back.garden.repository.chatentry.garden;
 
-import com.garden.back.global.exception.ChatRoomAccessException;
-import com.garden.back.garden.repository.chatentry.SessionId;
 import com.garden.back.garden.repository.chatentry.ChatRoomEntry;
-import org.springframework.stereotype.Repository;
+import com.garden.back.garden.repository.chatentry.SessionId;
+import com.garden.back.global.exception.ChatRoomAccessException;
+import org.springframework.stereotype.Component;
 
 import static com.garden.back.global.exception.ErrorCode.CHAT_ROOM_SESSION_ACCESS_ERROR;
 
-@Repository
+@Component
 public class GardenChatRoomEntryRepositoryImpl implements GardenChatRoomEntryRepository{
 
     private final GardenChatRoomRoomEntryLocalRepository gardenChatRoomRoomEntryLocalRepository;

--- a/chat/src/main/java/com/garden/back/garden/repository/chatentry/garden/GardenChatRoomRoomEntryLocalRepository.java
+++ b/chat/src/main/java/com/garden/back/garden/repository/chatentry/garden/GardenChatRoomRoomEntryLocalRepository.java
@@ -1,7 +1,7 @@
 package com.garden.back.garden.repository.chatentry.garden;
 
-import com.garden.back.garden.repository.chatentry.SessionId;
 import com.garden.back.garden.repository.chatentry.ChatRoomEntry;
+import com.garden.back.garden.repository.chatentry.SessionId;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -24,10 +24,7 @@ public class GardenChatRoomRoomEntryLocalRepository {
     }
 
     public boolean isMemberInRoom(ChatRoomEntry chatRoomEntry) {
-        if (chatEntries.get(chatRoomEntry.sessionId()) == null) {
-            return false;
-        }
-        return chatEntries.get(chatRoomEntry.sessionId()).equals(chatRoomEntry.chatRoomEntryInfo());
+        return chatEntries.get(chatRoomEntry.sessionId()) != null;
     }
 
     public boolean isContainsRoomIdAndMember(Long roomId, Long memberId) {

--- a/chat/src/main/java/com/garden/back/garden/repository/websocketinfo/WebSocketInfo.java
+++ b/chat/src/main/java/com/garden/back/garden/repository/websocketinfo/WebSocketInfo.java
@@ -1,0 +1,7 @@
+package com.garden.back.garden.repository.websocketinfo;
+
+public record WebSocketInfo(
+    String sessionId,
+    Long memberId
+) {
+}

--- a/chat/src/main/java/com/garden/back/garden/repository/websocketinfo/WebSocketInfoLocalRepository.java
+++ b/chat/src/main/java/com/garden/back/garden/repository/websocketinfo/WebSocketInfoLocalRepository.java
@@ -1,0 +1,20 @@
+package com.garden.back.garden.repository.websocketinfo;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class WebSocketInfoLocalRepository {
+
+    Map<String, Long> webSocketInfo = new ConcurrentHashMap<>();
+
+    public void save(String sessionId, Long memberId) {
+        webSocketInfo.put(sessionId, memberId);
+    }
+
+    public Long getMemberId(String sessionId) {
+        return webSocketInfo.get(sessionId);
+    }
+}

--- a/chat/src/main/java/com/garden/back/garden/repository/websocketinfo/WebSocketInfoRepository.java
+++ b/chat/src/main/java/com/garden/back/garden/repository/websocketinfo/WebSocketInfoRepository.java
@@ -1,0 +1,8 @@
+package com.garden.back.garden.repository.websocketinfo;
+
+public interface WebSocketInfoRepository {
+
+    void save(String sessionId, Long memberId);
+
+    Long getMemberId(String sessionId);
+}

--- a/chat/src/main/java/com/garden/back/garden/repository/websocketinfo/WebSocketInfoRepositoryImpl.java
+++ b/chat/src/main/java/com/garden/back/garden/repository/websocketinfo/WebSocketInfoRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.garden.back.garden.repository.websocketinfo;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class WebSocketInfoRepositoryImpl implements WebSocketInfoRepository{
+
+    private final WebSocketInfoLocalRepository webSocketInfoLocalRepository;
+
+    public WebSocketInfoRepositoryImpl(WebSocketInfoLocalRepository webSocketInfoLocalRepository) {
+        this.webSocketInfoLocalRepository = webSocketInfoLocalRepository;
+    }
+
+    @Override
+    public void save(String sessionId, Long memberId) {
+        webSocketInfoLocalRepository.save(sessionId, memberId);
+    }
+
+    @Override
+    public Long getMemberId(String sessionId) {
+        return webSocketInfoLocalRepository.getMemberId(sessionId);
+    }
+}

--- a/chat/src/test/java/com/garden/back/service/GardenChatServiceTest.java
+++ b/chat/src/test/java/com/garden/back/service/GardenChatServiceTest.java
@@ -3,6 +3,7 @@ package com.garden.back.service;
 import com.garden.back.garden.domain.GardenChatMessage;
 import com.garden.back.garden.repository.chatentry.garden.GardenChatRoomEntryRepository;
 import com.garden.back.garden.repository.chatmessage.GardenChatMessageRepository;
+import com.garden.back.garden.repository.websocketinfo.WebSocketInfoRepository;
 import com.garden.back.garden.service.GardenChatRoomService;
 import com.garden.back.garden.service.GardenChatService;
 import com.garden.back.garden.service.dto.request.GardenChatMessageSendParam;
@@ -36,6 +37,9 @@ class GardenChatServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private GardenChatRoomEntryRepository gardenChatRoomEntryRepository;
+
+    @Autowired
+    private WebSocketInfoRepository webSocketInfoRepository;
 
     @DisplayName("텃밭 분양 관련 채팅 메세지를 보낼 때 상대방 유저가 채팅 세션에 접속 중이면 모두 읽음 메세지로 표시된다.")
     @Test
@@ -267,6 +271,20 @@ class GardenChatServiceTest extends IntegrationTestSupport {
         assertThat(gardenChatRoomsFindResult.chatMessageId()).isEqualTo(secondGardenChatMessageByPart.chatMessageId());
         assertThat(gardenChatRoomsFindResult.chatRoomId()).isEqualTo(gardenChatRoomId);
         assertThat(gardenChatRoomsFindResult.partnerId()).isEqualTo(partnerId);
+    }
+
+    @DisplayName("session id를 key로 member id를 value로 WebSocketInfo에 저장되는지 확인한다.")
+    @Test
+    void saveSocketInfo() {
+        // Given
+        String sessionId = "aaabbb_123d";
+        Long memberId = 1L;
+
+        // When
+        gardenChatService.saveSocketInfo(sessionId, memberId);
+
+        // Then
+        assertThat(webSocketInfoRepository.getMemberId(sessionId)).isEqualTo(memberId);
     }
 
 }


### PR DESCRIPTION
## 내용
- session id를 프론트에 요청했으나 알 수 없는 값이어서  AbstractSubProtocolEvent의 각 구현체로 작동하는 이벤트 리스너를 이용하여 구현하였습니다.
- CONNECT 요청일 때 session id와 member id를 각각 key와 value로 Map에 저장하고
- SUBSCRIBE 요청일 때 위 
    -  room id를 얻고
    -  session id를 통해 위 Map에서 member id를 얻어
    -  chat room entry를 만들었습니다. 

