### PR TITLE
refactor: 속닥속닥 api 응답 필드 수정, query dsl 서브쿼리 limit 제거 버그 해결

### DIFF
--- a/api/src/test/java/com/garden/back/docs/post/PostRestDocsTest.java
+++ b/api/src/test/java/com/garden/back/docs/post/PostRestDocsTest.java
@@ -84,7 +84,7 @@ class PostRestDocsTest extends RestDocsSupport {
     @DisplayName("게시글 상세 조회 api docs")
     @Test
     void findPostsDetails() throws Exception {
-        FindPostDetailsResponse response = new FindPostDetailsResponse(10L, 1L, "작성자", "내용", "제목", LocalDate.now(), false, List.of("이미지 url"));
+        FindPostDetailsResponse response = new FindPostDetailsResponse(10L, 1L, 1L, "내용", "제목", LocalDate.now(), false, List.of("이미지 url"));
         given(postQueryService.findPostById(any(), any())).willReturn(response);
 
         mockMvc.perform(get("/v1/posts/{postId}", 1L)
@@ -99,7 +99,7 @@ class PostRestDocsTest extends RestDocsSupport {
                 responseFields(
                     fieldWithPath("commentCount").type(NUMBER).description("댓글 수"),
                     fieldWithPath("likeCount").type(NUMBER).description("좋아요 수"),
-                    fieldWithPath("author").type(STRING).description("작성자"),
+                    fieldWithPath("authorId").type(NUMBER).description("작성자ID"),
                     fieldWithPath("content").type(STRING).description("내용"),
                     fieldWithPath("title").type(STRING).description("제목"),
                     fieldWithPath("createdDate").type(STRING).description("생성 일"),
@@ -112,7 +112,7 @@ class PostRestDocsTest extends RestDocsSupport {
     @DisplayName("특정 게시글의 댓글 조회 api docs")
     @Test
     void findPostsComments() throws Exception {
-        FindPostsAllCommentResponse response = new FindPostsAllCommentResponse(List.of(new FindPostsAllCommentResponse.CommentInfo(2L, 1L, 0L, "대댓글", "작성자2", false), new FindPostsAllCommentResponse.CommentInfo(1L, null, 0L, "댓글", "작성자1", false)));
+        FindPostsAllCommentResponse response = new FindPostsAllCommentResponse(List.of(new FindPostsAllCommentResponse.CommentInfo(2L, 1L, 0L, "대댓글", 2L, false), new FindPostsAllCommentResponse.CommentInfo(1L, null, 0L, "댓글", 1L, false)));
         FindAllCommentsParamRequest request = new FindAllCommentsParamRequest(0, 10, "RECENT_DATE");
         given(postQueryService.findAllCommentsByPostId(any(), any(), any())).willReturn(response);
 
@@ -134,13 +134,13 @@ class PostRestDocsTest extends RestDocsSupport {
                     parameterWithName("postId").description("게시글 id")
                 ),
                 responseFields(
-                    fieldWithPath("commentInfos").description("댓글 정보 목록"),
-                    fieldWithPath("commentInfos[].commentId").description("댓글 ID"),
-                    fieldWithPath("commentInfos[].parentId").description("부모 댓글 ID (대댓글인 경우)").optional(),
-                    fieldWithPath("commentInfos[].likeCount").description("좋아요 수"),
-                    fieldWithPath("commentInfos[].content").description("댓글 내용"),
-                    fieldWithPath("commentInfos[].author").description("댓글 작성자"),
-                    fieldWithPath("commentInfos[].isLikeClick").description("현재 로그인 사용자가 이 댓글을 좋아요 했는지 안했는지에 대한 boolean(true면 좋아요 누른 상태)")
+                    fieldWithPath("commentInfos").type(ARRAY).description("댓글 정보 목록"),
+                    fieldWithPath("commentInfos[].commentId").type(NUMBER).description("댓글 ID"),
+                    fieldWithPath("commentInfos[].parentId").type(NUMBER).description("부모 댓글 ID (대댓글인 경우)").optional(),
+                    fieldWithPath("commentInfos[].likeCount").type(NUMBER).description("좋아요 수"),
+                    fieldWithPath("commentInfos[].content").type(STRING).description("댓글 내용"),
+                    fieldWithPath("commentInfos[].authorId").type(NUMBER).description("댓글 작성자 ID"),
+                    fieldWithPath("commentInfos[].isLikeClick").type(BOOLEAN).description("현재 로그인 사용자가 이 댓글을 좋아요 했는지 안했는지에 대한 boolean(true면 좋아요 누른 상태)")
                 )
             ));
     }
@@ -383,7 +383,7 @@ class PostRestDocsTest extends RestDocsSupport {
     @DisplayName("실시간 인기 게시글 조회 api docs")
     @Test
     void findPopularPosts() throws Exception {
-        FindAllPopularPostsResponse response = new FindAllPopularPostsResponse(List.of(new FindAllPopularPostsResponse.PostInfo(1L, "제목", 2L, 3L, LocalDate.now())));
+        FindAllPopularPostsResponse response = new FindAllPopularPostsResponse(List.of(new FindAllPopularPostsResponse.PostInfo(1L, "제목", 2L, 3L, "내용", "미리보기 이미지 url", 1L, PostType.QUESTION, LocalDate.now())));
         FindAllPopularPostsRequest request = new FindAllPopularPostsRequest(0L, 10L, 1);
         given(postQueryService.findAllPopularPosts(request.toRepositoryRequest())).willReturn(response);
 
@@ -407,6 +407,10 @@ class PostRestDocsTest extends RestDocsSupport {
                     fieldWithPath("postInfos[].title").type(STRING).description("게시글 제목"),
                     fieldWithPath("postInfos[].likeCount").type(NUMBER).description("좋아요 수"),
                     fieldWithPath("postInfos[].commentCount").type(NUMBER).description("댓글 수"),
+                    fieldWithPath("postInfos[].content").type(STRING).description("내용"),
+                    fieldWithPath("postInfos[].preview").type(STRING).description("미리보기 이미지"),
+                    fieldWithPath("postInfos[].authorId").type(NUMBER).description("글쓴이 아이디"),
+                    fieldWithPath("postInfos[].postType").type(STRING).description("게시글 종류"),
                     fieldWithPath("postInfos[].createdDate").type(STRING).description("생성 일")
                 )
             ));

--- a/core/src/main/java/com/garden/back/post/domain/repository/response/FindAllPopularPostsResponse.java
+++ b/core/src/main/java/com/garden/back/post/domain/repository/response/FindAllPopularPostsResponse.java
@@ -1,6 +1,7 @@
 package com.garden.back.post.domain.repository.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.garden.back.post.domain.PostType;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -13,6 +14,10 @@ public record FindAllPopularPostsResponse(
         String title,
         Long likeCount,
         Long commentCount,
+        String content,
+        String preview,
+        Long authorId,
+        PostType postType,
         @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate createdDate
     ) {}

--- a/core/src/main/java/com/garden/back/post/domain/repository/response/FindPostDetailsResponse.java
+++ b/core/src/main/java/com/garden/back/post/domain/repository/response/FindPostDetailsResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 public record FindPostDetailsResponse(
     Long commentCount,
     Long likeCount,
-    String author,
+    Long authorId,
     String content,
     String title,
     @JsonFormat(pattern = "yyyy-MM-dd")

--- a/core/src/main/java/com/garden/back/post/domain/repository/response/FindPostsAllCommentResponse.java
+++ b/core/src/main/java/com/garden/back/post/domain/repository/response/FindPostsAllCommentResponse.java
@@ -10,7 +10,7 @@ public record FindPostsAllCommentResponse(
         Long parentId,
         Long likeCount,
         String content,
-        String author,
+        Long authorId,
         Boolean isLikeClick
     ) {}
 }

--- a/core/src/test/java/com/garden/back/post/service/PostQueryServiceTest.java
+++ b/core/src/test/java/com/garden/back/post/service/PostQueryServiceTest.java
@@ -56,7 +56,7 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         Post post = Post.create(title, content, savedMemberId, List.of("http://example.com/image.jpg"), PostType.QUESTION);
         Post savedPost = postRepository.save(post);
         postCommandService.addLikeToPost(post.getId(), savedMemberId);
-        FindPostDetailsResponse response = new FindPostDetailsResponse(post.getCommentsCount(), post.getLikesCount(), nickname, content, title, savedPost.getCreatedDate(), true, List.of(imageUrl));
+        FindPostDetailsResponse response = new FindPostDetailsResponse(post.getCommentsCount(), post.getLikesCount(), post.getPostAuthorId(), content, title, savedPost.getCreatedDate(), true, List.of(imageUrl));
 
         //when & then
         assertThat(postQueryService.findPostById(savedPost.getId(), savedMemberId)).isEqualTo(response);
@@ -236,8 +236,8 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         FindAllPostCommentsParamRepositoryRequest request = new FindAllPostCommentsParamRepositoryRequest(0, 10, FindAllPostCommentsParamRepositoryRequest.OrderBy.RECENT_DATE);
         FindPostsAllCommentResponse response = new FindPostsAllCommentResponse(
             List.of(
-                new FindPostsAllCommentResponse.CommentInfo(recentCommentId, null, postComment2.getLikesCount(), content, nickname, true),
-                new FindPostsAllCommentResponse.CommentInfo(olderCommentId, null, postComment.getLikesCount(), content, nickname, false)
+                new FindPostsAllCommentResponse.CommentInfo(recentCommentId, null, postComment2.getLikesCount(), content, postComment2.getAuthorId(), true),
+                new FindPostsAllCommentResponse.CommentInfo(olderCommentId, null, postComment.getLikesCount(), content, postComment.getAuthorId(), false)
             )
         );
         assertThat(postQueryService.findAllCommentsByPostId(savedPostId, savedMemberId, request)).isEqualTo(response);
@@ -267,8 +267,8 @@ class PostQueryServiceTest extends IntegrationTestSupport {
 
         FindPostsAllCommentResponse response = new FindPostsAllCommentResponse(
             List.of(
-                new FindPostsAllCommentResponse.CommentInfo(havMoreLikeCommentId, null, postComment2.getLikesCount(), content, nickname, true),
-                new FindPostsAllCommentResponse.CommentInfo(haveLessCommentLikeId, null, postComment.getLikesCount(), content, nickname, false)
+                new FindPostsAllCommentResponse.CommentInfo(havMoreLikeCommentId, null, postComment2.getLikesCount(), content, postComment2.getAuthorId(), true),
+                new FindPostsAllCommentResponse.CommentInfo(haveLessCommentLikeId, null, postComment.getLikesCount(), content, postComment.getAuthorId(), false)
             )
         );
         assertThat(postQueryService.findAllCommentsByPostId(savedPostId, savedMemberId, request)).isEqualTo(response);
@@ -297,8 +297,8 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         FindAllPostCommentsParamRepositoryRequest request = new FindAllPostCommentsParamRepositoryRequest(0, 10, FindAllPostCommentsParamRepositoryRequest.OrderBy.OLDER_DATE);
         FindPostsAllCommentResponse response = new FindPostsAllCommentResponse(
             List.of(
-                new FindPostsAllCommentResponse.CommentInfo(olderCommentId, null, postComment.getLikesCount(), content, nickname, false),
-                new FindPostsAllCommentResponse.CommentInfo(recentCommentId, null, postComment2.getLikesCount(), content, nickname, true)
+                new FindPostsAllCommentResponse.CommentInfo(olderCommentId, null, postComment.getLikesCount(), content, postComment.getAuthorId(), false),
+                new FindPostsAllCommentResponse.CommentInfo(recentCommentId, null, postComment2.getLikesCount(), content, postComment2.getAuthorId(), true)
             )
         );
         assertThat(postQueryService.findAllCommentsByPostId(savedPostId, savedMemberId, request)).isEqualTo(response);
@@ -385,8 +385,8 @@ class PostQueryServiceTest extends IntegrationTestSupport {
         //when & then
         FindAllPopularRepositoryPostsRequest request = new FindAllPopularRepositoryPostsRequest(0L, 10L, 1);
         FindAllPopularPostsResponse response = new FindAllPopularPostsResponse(List.of(
-            new FindAllPopularPostsResponse.PostInfo(savedPostId1, title, post.getLikesCount(), post.getCommentsCount(), post.getCreatedDate()),
-            new FindAllPopularPostsResponse.PostInfo(savedPostId2, title, post2.getLikesCount(), post2.getCommentsCount(), post2.getCreatedDate())
+            new FindAllPopularPostsResponse.PostInfo(savedPostId1, title, post.getLikesCount(), post.getCommentsCount(), post.getContent(), post.getPostImages().stream().findFirst().get().getImageUrl(), post.getPostAuthorId(), post.getPostType(), post.getCreatedDate()),
+            new FindAllPopularPostsResponse.PostInfo(savedPostId2, title, post2.getLikesCount(), post2.getCommentsCount(), post2.getContent(), post2.getPostImages().stream().findFirst().get().getImageUrl(), post2.getPostAuthorId(), post.getPostType(), post.getCreatedDate())
         ));
         assertThat(postQueryService.findAllPopularPosts(request)).isEqualTo(response);
     }


### PR DESCRIPTION
## 내용
클라이언트 요구사항에 맞춰 api 필드를 수정했습니다. query dsl에서 서브쿼리 내에 limit 절이 제거되는 버그를 집계함수로 해결했습니다.

## 테스트 방법


## 추가 정보
이 PR과 관련된 추가적인 정보가 있다면 여기에 적어주세요.
