### PR TITLE
refactor : 텃밭 찜하기 응답으로 자원 식별자 추가

### DIFF
--- a/api/src/main/java/com/garden/back/garden/controller/GardenCommandController.java
+++ b/api/src/main/java/com/garden/back/garden/controller/GardenCommandController.java
@@ -1,6 +1,7 @@
 package com.garden.back.garden.controller;
 
 import com.garden.back.garden.controller.dto.request.*;
+import com.garden.back.garden.controller.dto.response.GardenLikeCreateResponse;
 import com.garden.back.garden.service.GardenCommandService;
 import com.garden.back.garden.service.dto.request.GardenDeleteParam;
 import com.garden.back.garden.service.dto.request.MyManagedGardenDeleteParam;
@@ -21,7 +22,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/v2/gardens")
 public class GardenCommandController {
-    private static final String GARDEN_DEFAULT_URL = "/v2/gardens";
+    private static final String GARDEN_DEFAULT_URL = "/v2/gardens/";
     private final GardenCommandService gardenCommandService;
 
     public GardenCommandController(GardenCommandService gardenCommandService) {
@@ -47,13 +48,14 @@ public class GardenCommandController {
         path = "/likes",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> createGardenLike(
+    public ResponseEntity<GardenLikeCreateResponse> createGardenLike(
         @RequestBody @Valid GardenLikeCreateRequest gardenLikeCreateRequest,
         @CurrentUser LoginUser loginUser) {
         Long gardenLikeId = gardenCommandService.createGardenLike(
             GardenLikeCreateRequest.of(loginUser.memberId(), gardenLikeCreateRequest));
 
-        return ResponseEntity.created(URI.create(GARDEN_DEFAULT_URL + gardenLikeId)).build();
+        return ResponseEntity.created(URI.create(GARDEN_DEFAULT_URL+"/likes/" + gardenLikeId))
+            .body(GardenLikeCreateResponse.to(gardenLikeId));
     }
 
     @DeleteMapping(

--- a/api/src/main/java/com/garden/back/garden/controller/dto/response/GardenLikeCreateResponse.java
+++ b/api/src/main/java/com/garden/back/garden/controller/dto/response/GardenLikeCreateResponse.java
@@ -1,0 +1,9 @@
+package com.garden.back.garden.controller.dto.response;
+
+public record GardenLikeCreateResponse(
+    long gardenLikeId
+) {
+    public static GardenLikeCreateResponse to(Long gardenLikeId) {
+        return new GardenLikeCreateResponse(gardenLikeId);
+    }
+}

--- a/api/src/test/java/com/garden/back/docs/garden/GardenCommandRestDocsTest.java
+++ b/api/src/test/java/com/garden/back/docs/garden/GardenCommandRestDocsTest.java
@@ -52,6 +52,9 @@ class GardenCommandRestDocsTest extends RestDocsSupport {
                 requestFields(
                     fieldWithPath("gardenId").type(JsonFieldType.NUMBER).description("찜하고자 하는 텃밭 아이디")
                 ),
+                responseFields(
+                    fieldWithPath("gardenLikeId").type(JsonFieldType.NUMBER).description("텃밭의 찜하기 ID")
+                ),
                 responseHeaders(
                     headerWithName("Location").description("생성된 찜한 텃밭의 id를 포함한 url")
                 )));


### PR DESCRIPTION
## 내용
기존에 자원 전이 상태의 location을 주던 것에 response 응답도 추가


