### PR TITLE
refactor : Restful 하도록 수정

### DIFF
--- a/api/src/main/java/com/garden/back/garden/controller/GardenCommandController.java
+++ b/api/src/main/java/com/garden/back/garden/controller/GardenCommandController.java
@@ -4,11 +4,14 @@ import com.garden.back.garden.controller.dto.request.*;
 import com.garden.back.garden.controller.dto.response.GardenLikeCreateResponse;
 import com.garden.back.garden.service.GardenCommandService;
 import com.garden.back.garden.service.dto.request.GardenDeleteParam;
+import com.garden.back.garden.service.dto.request.GardenLikeCreateParam;
+import com.garden.back.garden.service.dto.request.GardenLikeDeleteParam;
 import com.garden.back.garden.service.dto.request.MyManagedGardenDeleteParam;
 import com.garden.back.global.LocationBuilder;
 import com.garden.back.global.loginuser.CurrentUser;
 import com.garden.back.global.loginuser.LoginUser;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -45,28 +48,35 @@ public class GardenCommandController {
     }
 
     @PostMapping(
-        path = "/likes",
+        path = "/{gardenId}/likes",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<GardenLikeCreateResponse> createGardenLike(
-        @RequestBody @Valid GardenLikeCreateRequest gardenLikeCreateRequest,
+        @PathVariable
+        @Positive(message = "gardenId는 양수여아 합니다.")
+        @NotNull(message = "gardenId는 null일 수 없습니다.")
+        Long gardenId,
         @CurrentUser LoginUser loginUser) {
         Long gardenLikeId = gardenCommandService.createGardenLike(
-            GardenLikeCreateRequest.of(loginUser.memberId(), gardenLikeCreateRequest));
+            GardenLikeCreateParam.to(loginUser.memberId(), gardenId));
 
-        return ResponseEntity.created(URI.create(GARDEN_DEFAULT_URL+"/likes/" + gardenLikeId))
+        return ResponseEntity.created(
+                URI.create(String.format(GARDEN_DEFAULT_URL + "/%d/likes/%d", gardenId, gardenLikeId)))
             .body(GardenLikeCreateResponse.to(gardenLikeId));
     }
 
     @DeleteMapping(
-        path = "/likes",
+        path = "/likes/{gardenLikeId}",
         consumes = MediaType.APPLICATION_JSON_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Void> deleteGardenLike(
-        @RequestBody @Valid GardenLikeDeleteRequest gardenLikeDeleteRequest,
+        @PathVariable
+        @Positive(message = "gardenLikeId는 양수여아 합니다.")
+        @NotNull(message = "gardenLikeId는 null일 수 없습니다.")
+        Long gardenLikeId,
         @CurrentUser LoginUser loginUser) {
         gardenCommandService.deleteGardenLike(
-            GardenLikeDeleteRequest.of(loginUser.memberId(), gardenLikeDeleteRequest));
+            GardenLikeDeleteParam.to(loginUser.memberId(), gardenLikeId));
 
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/api/src/main/java/com/garden/back/garden/controller/dto/request/GardenLikeCreateRequest.java
+++ b/api/src/main/java/com/garden/back/garden/controller/dto/request/GardenLikeCreateRequest.java
@@ -5,14 +5,13 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 public record GardenLikeCreateRequest (
-        @NotNull
-        @Positive
         Long gardenId
 ) {
-    public static GardenLikeCreateParam of(Long memberId, GardenLikeCreateRequest gardenLikeCreateRequest) {
+    public static GardenLikeCreateParam of(Long memberId,
+                                           Long gardenId) {
         return new GardenLikeCreateParam(
                 memberId,
-                gardenLikeCreateRequest.gardenId()
+                gardenId
         );
     }
 }

--- a/api/src/main/java/com/garden/back/garden/controller/dto/response/GardenDetailResponse.java
+++ b/api/src/main/java/com/garden/back/garden/controller/dto/response/GardenDetailResponse.java
@@ -22,7 +22,7 @@ public record GardenDetailResponse(
     String gardenDescription,
     List<String> images,
     GardenDetailResult.GardenFacility gardenFacility,
-    boolean isLiked,
+    Long gardenLikeId,
     Long roomId
 ) {
     public static GardenDetailResponse to(GardenDetailFacadeResponse result) {
@@ -43,7 +43,7 @@ public record GardenDetailResponse(
             result.gardenDescription(),
             result.images(),
             result.gardenFacility(),
-            result.isLiked(),
+            result.gardenLikeId(),
             result.roomId()
         );
     }

--- a/api/src/main/java/com/garden/back/garden/facade/GardenDetailFacadeResponse.java
+++ b/api/src/main/java/com/garden/back/garden/facade/GardenDetailFacadeResponse.java
@@ -21,7 +21,7 @@ public record GardenDetailFacadeResponse (
     String gardenDescription,
     List<String> images,
     GardenDetailResult.GardenFacility gardenFacility,
-    boolean isLiked,
+    Long gardenLikeId,
     Long roomId
 ) {
 
@@ -45,7 +45,7 @@ public record GardenDetailFacadeResponse (
             result.gardenDescription(),
             result.images(),
             result.gardenFacility(),
-            result.isLiked(),
+            result.gardenLikeId(),
             roomId
         );
     }

--- a/api/src/test/java/com/garden/back/docs/garden/GardenCommandRestDocsTest.java
+++ b/api/src/test/java/com/garden/back/docs/garden/GardenCommandRestDocsTest.java
@@ -40,17 +40,15 @@ class GardenCommandRestDocsTest extends RestDocsSupport {
     @DisplayName("텃밭을 찜할 수 있다.")
     @Test
     void createLikeGarden() throws Exception {
-        GardenLikeCreateRequest gardenLikeCreateRequest = GardenFixture.gardenLikeCreateRequest();
         given(gardenCommandService.createGardenLike(any())).willReturn(1L);
 
-        mockMvc.perform(post("/v2/gardens/likes")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(gardenLikeCreateRequest)))
+        mockMvc.perform(post("/v2/gardens/{gardenId}/likes",1L)
+                .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isCreated())
             .andDo(document("create-like-garden",
-                requestFields(
-                    fieldWithPath("gardenId").type(JsonFieldType.NUMBER).description("찜하고자 하는 텃밭 아이디")
+                pathParameters(
+                    parameterWithName("gardenId").description("해당 텃밭 게시글의 ID")
                 ),
                 responseFields(
                     fieldWithPath("gardenLikeId").type(JsonFieldType.NUMBER).description("텃밭의 찜하기 ID")
@@ -63,16 +61,13 @@ class GardenCommandRestDocsTest extends RestDocsSupport {
     @DisplayName("텃밭을 삭제할 수 있다.")
     @Test
     void deleteLikeGarden() throws Exception {
-        GardenLikeDeleteRequest gardenLikeDeleteRequest = GardenFixture.gardenLikeDeleteRequest();
-
-        mockMvc.perform(delete("/v2/gardens/likes")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(gardenLikeDeleteRequest)))
+        mockMvc.perform(delete("/v2/gardens/likes/{gardenLikeId}",1L)
+                .contentType(MediaType.APPLICATION_JSON))
             .andDo(print())
             .andExpect(status().isOk())
             .andDo(document("delete-like",
-                requestFields(
-                    fieldWithPath("gardenId").type(JsonFieldType.NUMBER).description("찜하기를 취소하고자 하는 텃밭 아이디")
+                pathParameters(
+                    parameterWithName("gardenLikeId").description("텃밭 찜하기 ID")
                 )));
     }
 

--- a/api/src/test/java/com/garden/back/docs/garden/GardenFixture.java
+++ b/api/src/test/java/com/garden/back/docs/garden/GardenFixture.java
@@ -77,7 +77,7 @@ public class GardenFixture {
                 true,
                 true
             ),
-            true,
+            1L,
             1L
         );
     }

--- a/api/src/test/java/com/garden/back/docs/garden/GardenRestDocsTest.java
+++ b/api/src/test/java/com/garden/back/docs/garden/GardenRestDocsTest.java
@@ -163,7 +163,7 @@ class GardenRestDocsTest extends RestDocsSupport {
                     fieldWithPath("gardenFacility.isToilet").type(JsonFieldType.BOOLEAN).description("텃밭 화장실 제공 여부"),
                     fieldWithPath("gardenFacility.isWaterway").type(JsonFieldType.BOOLEAN).description("텃밭 수로 제공 여부"),
                     fieldWithPath("gardenFacility.isEquipment").type(JsonFieldType.BOOLEAN).description("농기구 제공 여부"),
-                    fieldWithPath("isLiked").type(JsonFieldType.BOOLEAN).description("좋아요 여부"),
+                    fieldWithPath("gardenLikeId").type(JsonFieldType.NUMBER).description("해당 텃밭 찜하기 ID, 텃밭을 찜하지 않았다면 0을 반환하고 텃밭을 찜했다면 0보다 큰 수를 응답한다."),
                     fieldWithPath("roomId").type(JsonFieldType.NUMBER).description("해당 게시글에 대한 채팅방 아이디, 만약 채팅방이 없는 경우에는 -1L를 반환합니다.")
                 )));
     }

--- a/core/src/main/java/com/garden/back/garden/repository/garden/GardenJpaRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/garden/GardenJpaRepository.java
@@ -63,7 +63,10 @@ public interface GardenJpaRepository extends JpaRepository<GardenEntity, Long> {
                 g.recruitEndDate as recruitEndDate,
                 g.gardenDescription as gardenDescription,
                 gi.imageUrl as imageUrl,
-                CASE WHEN l.garden.gardenId IS NOT NULL THEN true ELSE false END as isLiked,
+                CASE
+                        WHEN l.garden.gardenId IS NOT NULL THEN l.garden.gardenId
+                        ELSE 0
+                    END as gardenLikeId,
                 g.isToilet as isToilet,
                 g.isWaterway as isWaterway,
                 g.isEquipment as isEquipment

--- a/core/src/main/java/com/garden/back/garden/repository/garden/dto/response/GardenDetailRepositoryResponse.java
+++ b/core/src/main/java/com/garden/back/garden/repository/garden/dto/response/GardenDetailRepositoryResponse.java
@@ -24,5 +24,5 @@ public interface GardenDetailRepositoryResponse {
     boolean getIsToilet();
     boolean getIsWaterway();
     boolean getIsEquipment();
-    boolean getIsLiked();
+    Long getGardenLikeId();
 }

--- a/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeJpaRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeJpaRepository.java
@@ -13,9 +13,9 @@ public interface GardenLikeJpaRepository extends JpaRepository<GardenLikeEntity,
     @Modifying(clearAutomatically = true)
     @Query(
             """
-            delete from GardenLikeEntity as gl where gl.garden.gardenId =:gardenId and gl.memberId=:memberId
+            delete from GardenLikeEntity as gl where gl.gardenLikeId =:gardenLikeId and gl.memberId=:memberId
             """)
-    void delete(@Param("memberId") Long memberId, @Param("gardenId") Long gardenId);
+    void delete(@Param("memberId") Long memberId, @Param("gardenLikeId") Long gardenLikeId);
 
     @Query(
         """

--- a/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface GardenLikeRepository {
     GardenLike save(GardenLike gardenLike);
 
-    void delete(Long memberId, Long gardenId);
+    void delete(Long memberId, Long gardenLikeId);
 
     List<GardenLike> findAll();
 

--- a/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeRepositoryImpl.java
+++ b/core/src/main/java/com/garden/back/garden/repository/gardenlike/GardenLikeRepositoryImpl.java
@@ -26,8 +26,8 @@ public class GardenLikeRepositoryImpl implements GardenLikeRepository {
     }
 
     @Override
-    public void delete(Long memberId, Long gardenId) {
-        gardenLikeJpaRepository.delete(memberId, gardenId);
+    public void delete(Long memberId, Long gardenLikeId) {
+        gardenLikeJpaRepository.delete(memberId, gardenLikeId);
     }
 
     @Override

--- a/core/src/main/java/com/garden/back/garden/service/GardenCommandService.java
+++ b/core/src/main/java/com/garden/back/garden/service/GardenCommandService.java
@@ -66,7 +66,7 @@ public class GardenCommandService {
 
     @Transactional
     public void deleteGardenLike(GardenLikeDeleteParam param) {
-        gardenLikeRepository.delete(param.memberId(), param.gardenId());
+        gardenLikeRepository.delete(param.memberId(), param.gardenLikeId());
     }
 
     @Transactional

--- a/core/src/main/java/com/garden/back/garden/service/dto/request/GardenLikeCreateParam.java
+++ b/core/src/main/java/com/garden/back/garden/service/dto/request/GardenLikeCreateParam.java
@@ -1,7 +1,16 @@
 package com.garden.back.garden.service.dto.request;
 
 public record GardenLikeCreateParam(
+    Long memberId,
+    Long gardenId
+) {
+    public static GardenLikeCreateParam to(
         Long memberId,
         Long gardenId
-) {
+    ) {
+        return new GardenLikeCreateParam(
+            memberId,
+            gardenId
+        );
+    }
 }

--- a/core/src/main/java/com/garden/back/garden/service/dto/request/GardenLikeDeleteParam.java
+++ b/core/src/main/java/com/garden/back/garden/service/dto/request/GardenLikeDeleteParam.java
@@ -2,6 +2,12 @@ package com.garden.back.garden.service.dto.request;
 
 public record GardenLikeDeleteParam(
         Long memberId,
-        Long gardenId
+        Long gardenLikeId
 ) {
+    public static GardenLikeDeleteParam to(
+        Long memberId,
+        Long gardenLikeId
+    ) {
+        return new GardenLikeDeleteParam(memberId, gardenLikeId);
+    }
 }

--- a/core/src/main/java/com/garden/back/garden/service/dto/response/GardenDetailResult.java
+++ b/core/src/main/java/com/garden/back/garden/service/dto/response/GardenDetailResult.java
@@ -23,7 +23,7 @@ public record GardenDetailResult(
         String gardenDescription,
         List<String> images,
         GardenFacility gardenFacility,
-        boolean isLiked
+        Long gardenLikeId
 ) {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
@@ -54,7 +54,7 @@ public record GardenDetailResult(
                         gardenDetailRepositoryResponse.getIsWaterway(),
                         gardenDetailRepositoryResponse.getIsEquipment()
                 ),
-                gardenDetailRepositoryResponse.getIsLiked()
+                gardenDetailRepositoryResponse.getGardenLikeId()
         );
     }
 

--- a/core/src/test/java/com/garden/back/testutil/garden/GardenFixture.java
+++ b/core/src/test/java/com/garden/back/testutil/garden/GardenFixture.java
@@ -2,6 +2,7 @@ package com.garden.back.testutil.garden;
 
 import com.garden.back.garden.domain.Garden;
 import com.garden.back.garden.domain.GardenImage;
+import com.garden.back.garden.domain.GardenLike;
 import com.garden.back.garden.domain.MyManagedGarden;
 import com.garden.back.garden.domain.vo.GardenStatus;
 import com.garden.back.garden.domain.vo.GardenType;
@@ -25,6 +26,7 @@ public class GardenFixture {
     private static final LocalDate RECRUIT_END_DATE = LocalDate.of(2023, 12, 7);
     private static final LocalDate USE_START_DATE = LocalDate.of(2023, 11, 1);
     private static final LocalDate USE_END_DATE = LocalDate.of(2023, 12, 7);
+
     private GardenFixture() {
         throw new RuntimeException("생성자를 통해 객체를 만들 수 없습니다.");
     }
@@ -368,6 +370,10 @@ public class GardenFixture {
             "https://kr.object.ncloudstorage.com/every-garden/images/garden/background.jpg",
             gardenId
         );
+    }
+
+    public static GardenLike gardenLike(Garden garden, Long memberId) {
+        return GardenLike.of(memberId, garden);
     }
 
 }


### PR DESCRIPTION
## 내용
- 텃밭 찜하기 취소:  body로 받았던 garden id (삭제하고자 하는 식별자가 아님)  ➡️ path variable로 gardenLikeId 삭제하고자 하는 자원 식별자
- 텃밭 상세보기 : 위 수정 사항으로 인해서 텃밭 상세보기 응답 필드를 boolean isLiked ➡️ Long gardenLikeId를 보여주도록 수정
- 텃밭 찜하기 : garden id를 body 안에 담았던 것을 ➡️ gardens/{gardenId}/likes path variable로 받도록 수정

