### PR TITLE
feat : 텃밭 상세보기 쿼리 수정 및 그에 따른 서비스 테스트 추가

### DIFF
--- a/core/src/main/java/com/garden/back/garden/repository/garden/GardenJpaRepository.java
+++ b/core/src/main/java/com/garden/back/garden/repository/garden/GardenJpaRepository.java
@@ -64,7 +64,7 @@ public interface GardenJpaRepository extends JpaRepository<GardenEntity, Long> {
                 g.gardenDescription as gardenDescription,
                 gi.imageUrl as imageUrl,
                 CASE
-                        WHEN l.garden.gardenId IS NOT NULL THEN l.garden.gardenId
+                        WHEN l.gardenLikeId IS NOT NULL THEN l.gardenLikeId
                         ELSE 0
                     END as gardenLikeId,
                 g.isToilet as isToilet,

--- a/core/src/test/java/com/garden/back/testutil/garden/GardenFixture.java
+++ b/core/src/test/java/com/garden/back/testutil/garden/GardenFixture.java
@@ -375,5 +375,4 @@ public class GardenFixture {
     public static GardenLike gardenLike(Garden garden, Long memberId) {
         return GardenLike.of(memberId, garden);
     }
-
 }


### PR DESCRIPTION
## 내용
- 텃밭 상세보기에서 gardenLikeId가 와야 하는데 gardenId가 반환되어 쿼리 수정

## 테스트 방법
- 그에 따라 텃밭 찜하기를 취소하고 다시 하는 경우에 매칭이 제대로 되는지 서비스 테스트 추가

