### PR TITLE
Feat/geo : 주소에 대한 위도 및 경도 반환 기능 구현

### DIFF
--- a/api/src/docs/asciidoc/region/region.adoc
+++ b/api/src/docs/asciidoc/region/region.adoc
@@ -10,3 +10,15 @@ include::{snippets}/search-regions/query-parameters.adoc[]
 
 ==== Response (Success)
 include::{snippets}/search-regions/http-response.adoc[]
+
+[[search-regions-geocode]]
+=== 주소에 대한 위도 및 경도 검색 API
+주소에 대한 위도 및 경도 검색 API
+
+==== Request
+include::{snippets}/search-regions-geocode/http-request.adoc[]
+include::{snippets}/search-regions-geocode/query-parameters.adoc[]
+
+
+==== Response (Success)
+include::{snippets}/search-regions-geocode/http-response.adoc[]

--- a/api/src/main/java/com/garden/back/region/GeoResponse.java
+++ b/api/src/main/java/com/garden/back/region/GeoResponse.java
@@ -1,0 +1,14 @@
+package com.garden.back.region;
+
+public record GeoResponse(
+    String latitude,
+    String longitude
+) {
+
+    public static GeoResponse of(GeoResult result) {
+        return new GeoResponse(
+            result.latitude(),
+            result.longitude()
+        );
+    }
+}

--- a/api/src/main/java/com/garden/back/region/RegionController.java
+++ b/api/src/main/java/com/garden/back/region/RegionController.java
@@ -3,10 +3,7 @@ package com.garden.back.region;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/regions")
@@ -20,5 +17,14 @@ public class RegionController {
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<LocationSearchApiResponses> findByRegionName(@ModelAttribute @Valid LocationSearchApiRequest request) {
         return ResponseEntity.ok(regionService.autoCompleteRegion(request.toServiceRequest()));
+    }
+
+    @GetMapping(
+        value = "/geocode",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<GeoResponse> getLatitudeAndLongitude(
+        @RequestParam String fullAddress ) {
+        return ResponseEntity.ok(
+            GeoResponse.of(regionService.getLatitudeAndLongitude(fullAddress)));
     }
 }

--- a/api/src/test/java/com/garden/back/docs/region/RegionFixture.java
+++ b/api/src/test/java/com/garden/back/docs/region/RegionFixture.java
@@ -1,0 +1,9 @@
+package com.garden.back.docs.region;
+
+import com.garden.back.region.GeoResult;
+
+public class RegionFixture {
+    public static GeoResult geoResult() {
+        return new GeoResult("37.5200747", "126.6711079");
+    }
+}

--- a/api/src/test/java/com/garden/back/docs/region/RegionRestDocsTest.java
+++ b/api/src/test/java/com/garden/back/docs/region/RegionRestDocsTest.java
@@ -69,4 +69,26 @@ class RegionRestDocsTest extends RestDocsSupport {
                 )
             ));
     }
+
+    @DisplayName("지역명에 대한 위도 경도 반환 API")
+    @Test
+    void getLatitudeAndLongitude() throws Exception {
+        given(regionService.getLatitudeAndLongitude(any())).willReturn(RegionFixture.geoResult());
+
+        mockMvc.perform(get("/v1/regions/geocode")
+                .param("fullAddress", "인천광역시 서구 가정로 334")
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding(StandardCharsets.UTF_8))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(document("search-regions-geocode",
+                queryParameters(
+                    parameterWithName("fullAddress").description("조회할 주소")
+                ),
+                responseFields(
+                    fieldWithPath("latitude").type(STRING).description("위도"),
+                    fieldWithPath("longitude").type(STRING).description("경도")
+                )
+            ));
+    }
 }

--- a/core/src/main/java/com/garden/back/region/GeoResult.java
+++ b/core/src/main/java/com/garden/back/region/GeoResult.java
@@ -1,0 +1,17 @@
+package com.garden.back.region;
+
+import com.garden.back.region.infra.api.GeoResponse;
+
+public record GeoResult(
+    String latitude,
+    String longitude
+) {
+    private static final int detailResultIndex = 0;
+
+    public static GeoResult of(GeoResponse response) {
+        return new GeoResult(
+            response.addresses().get(detailResultIndex).y(),
+            response.addresses().get(detailResultIndex).x()
+        );
+    }
+}

--- a/core/src/main/java/com/garden/back/region/RegionService.java
+++ b/core/src/main/java/com/garden/back/region/RegionService.java
@@ -1,5 +1,6 @@
 package com.garden.back.region;
 
+import com.garden.back.region.infra.api.NaverGeoCodeClient;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -7,8 +8,12 @@ public class RegionService {
 
     private final RegionRepository regionRepository;
 
-    public RegionService(RegionRepository regionRepository) {
+    private final NaverGeoCodeClient naverGeoCodeClient;
+
+    public RegionService(RegionRepository regionRepository,
+                         NaverGeoCodeClient naverGeoCodeClient) {
         this.regionRepository = regionRepository;
+        this.naverGeoCodeClient = naverGeoCodeClient;
     }
 
     public LocationSearchApiResponses autoCompleteRegion(LocationSearchServiceRequest request) {
@@ -18,5 +23,9 @@ public class RegionService {
                 .map(LocationSearchApiResponses.LocationSearchResponse::from)
                 .toList()
         );
+    }
+
+    public GeoResult getLatitudeAndLongitude(String fullAddress) {
+        return GeoResult.of(naverGeoCodeClient.getLatitudeAndLongitude(fullAddress));
     }
 }

--- a/core/src/main/java/com/garden/back/region/infra/api/GeoResponse.java
+++ b/core/src/main/java/com/garden/back/region/infra/api/GeoResponse.java
@@ -1,0 +1,37 @@
+package com.garden.back.region.infra.api;
+
+import java.util.List;
+
+public record GeoResponse(
+    String status,
+    Meta meta,
+    List<Address> addresses
+) {
+    public record Meta(
+        int totalCount,
+        int page,
+        int count
+    ) {
+    }
+
+    public record Address(
+        String roadAddress,
+        String jibunAddress,
+        String englishAddress,
+        List<AddressElement> addressElements,
+        String x,
+        String y,
+        double distance
+    ) {
+        public record AddressElement(
+            List<String> types,
+            String longName,
+            String shortName,
+            String code
+        ) {
+        }
+
+    }
+}
+
+

--- a/core/src/main/java/com/garden/back/region/infra/api/NaverGeoCodeClient.java
+++ b/core/src/main/java/com/garden/back/region/infra/api/NaverGeoCodeClient.java
@@ -1,0 +1,21 @@
+package com.garden.back.region.infra.api;
+
+import com.garden.back.region.infra.config.NaverFeignConfig;
+import com.garden.back.weather.infra.api.naver.NaverGeoClient;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(
+    name ="naver-geocode-client",
+    url = "https://naveropenapi.apigw.ntruss.com/map-geocode/v2/geocode",
+    fallbackFactory = NaverGeoClient.NaverGeoClientFallback.class,
+    configuration = NaverFeignConfig.class
+)
+public interface NaverGeoCodeClient {
+
+    @GetMapping
+    GeoResponse getLatitudeAndLongitude(
+        @RequestParam("query") String fullAddress);
+
+}

--- a/core/src/main/java/com/garden/back/region/infra/config/NaverFeignConfig.java
+++ b/core/src/main/java/com/garden/back/region/infra/config/NaverFeignConfig.java
@@ -1,0 +1,13 @@
+package com.garden.back.region.infra.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class NaverFeignConfig {
+
+    @Bean
+    public NaverRequestInterceptor naverRequestInterceptor() {
+        return new NaverRequestInterceptor();
+    }
+}

--- a/core/src/main/java/com/garden/back/region/infra/config/NaverRequestInterceptor.java
+++ b/core/src/main/java/com/garden/back/region/infra/config/NaverRequestInterceptor.java
@@ -1,0 +1,20 @@
+package com.garden.back.region.infra.config;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.beans.factory.annotation.Value;
+
+public class NaverRequestInterceptor implements RequestInterceptor {
+
+    @Value("${api.reverseGeo.id}")
+    private String naverApiId;
+
+    @Value("${api.reverseGeo.secret}")
+    private String naverApiSecret;
+
+    @Override
+    public void apply(RequestTemplate requestTemplate) {
+        requestTemplate.header("X-NCP-APIGW-API-KEY-ID", naverApiId);
+        requestTemplate.header("X-NCP-APIGW-API-KEY", naverApiSecret);
+    }
+}


### PR DESCRIPTION
## 내용
주소에 대한 위도 및 경도 반환 기능 구현

## 추가 정보
- ReverseGeoCode와 헤더가 같으므로 이를 RequestHeader로 받지 않고 GeoCode 방식과 같이 RequestInterceptor로 configuration을 등록하면 될 거 같다. (추후 변경될 내용)
